### PR TITLE
Add basic actions, pre build (fails)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: Test actions for .NET MAUI App
+
+on: push
+
+jobs:
+  build:
+    name: Basic actions
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test actions
+      run: |
+        echo "Testing actions so we can use for testing later"
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 8.0.x
+    - name: Install MAUI workload
+      run: dotnet workload install maui
+#    - name: Build
+#      run: dotnet publish HaulageApplication/HaulageApp/HaulageApp.csproj -c Release -f:net8.0-windows10.0.19041.0 /p:GenerateAppxPackageOnBuild=true /p:AppxPackageSigningEnabled=false
+#    - name: Upload Build Artifacts
+#      uses: actions/upload-artifact@v3.1.0
+#      with:
+#        path: .\**\AppPackages\**\*.*


### PR DESCRIPTION
added github actions so that when we add any [unit] tests, we can have these run on push and ensure we don't add any breaking changes.

I wasn't able to add the build/package step but this might not be necessary to run the test files, so I thought this owuld still be worth committing.

Feel free to fix / look into :)

test: actions ran fine for this commit (see screenshot)

<img width="1735" alt="Screenshot 2024-08-14 at 15 05 52" src="https://github.com/user-attachments/assets/0daac898-f42e-4dad-9c14-99623d72922d">
