### PR TITLE
[#36] Add ability for existing users to log in to the app

### DIFF
--- a/HaulageApplication/.gitignore
+++ b/HaulageApplication/.gitignore
@@ -1,5 +1,6 @@
 .idea
-Notes/bin/
-Notes/obj/
 HaulageApp/bin
 HaulageApp/obj
+HaulageAppTests/bin
+HaulageAppTests/obj
+**.user

--- a/HaulageApplication/HaulageApp.sln
+++ b/HaulageApplication/HaulageApp.sln
@@ -2,6 +2,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HaulageApp", "HaulageApp\HaulageApp.csproj", "{27C30868-B5A8-4A55-AF23-BC5035F726BD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HaulageAppTests", "HaulageAppTests\HaulageAppTests.csproj", "{2ACB24EA-9C99-449A-908B-4741303511FC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,5 +14,9 @@ Global
 		{27C30868-B5A8-4A55-AF23-BC5035F726BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27C30868-B5A8-4A55-AF23-BC5035F726BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27C30868-B5A8-4A55-AF23-BC5035F726BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2ACB24EA-9C99-449A-908B-4741303511FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2ACB24EA-9C99-449A-908B-4741303511FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2ACB24EA-9C99-449A-908B-4741303511FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2ACB24EA-9C99-449A-908B-4741303511FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -4,18 +4,31 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:views="clr-namespace:HaulageApp.Views"
-    Shell.FlyoutBehavior="Disabled">
+    FlyoutBehavior="Disabled">
+    
+    <ShellContent
+        Title="Loading"
+        ContentTemplate="{DataTemplate views:LoadingPage}"
+        Route="loading" />
 
+    <ShellContent
+        Title="Login"
+        ContentTemplate="{DataTemplate views:LoginPage}"
+        Route="login"/>
+    
     <TabBar>
-        <ShellContent
-            Title="HaulageApp"
-            ContentTemplate="{DataTemplate views:AllNotesPage}"
-            Icon="{OnPlatform 'icon_notes.png', iOS='icon_notes_ios.png', MacCatalyst='icon_notes_ios.png'}" />
-
-        <ShellContent
-            Title="About"
-            ContentTemplate="{DataTemplate views:AboutPage}"
-            Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}" />
+        <Tab Title="Home" Icon="{OnPlatform 'icon_notes.png', iOS='icon_notes_ios.png', MacCatalyst='icon_notes_ios.png'}">
+            <ShellContent
+                Title="Home"
+                ContentTemplate="{DataTemplate views:AllNotesPage}"
+                Route="home"/>
+        </Tab>
+        
+        <Tab Title="About" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
+            <ShellContent
+                Title="About"
+                ContentTemplate="{DataTemplate views:AboutPage}"
+                Route="about"/>
+        </Tab>
     </TabBar>
-
 </Shell>

--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace HaulageApp;
+﻿using HaulageApp.Views;
+
+namespace HaulageApp;
 
 public partial class AppShell : Shell
 {
@@ -6,7 +8,8 @@ public partial class AppShell : Shell
     {
         InitializeComponent();
 
-        Routing.RegisterRoute(nameof(Views.NotePage), typeof(Views.NotePage));
-
+        Routing.RegisterRoute("home", typeof(AllNotesPage));
+        Routing.RegisterRoute("login", typeof(LoginPage));
+        Routing.RegisterRoute(nameof(NotePage), typeof(NotePage));
     }
 }

--- a/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
+++ b/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
@@ -11,5 +11,6 @@ namespace HaulageApp.Data
         { }
 
         public DbSet<Note> note { get; set; }
+        public DbSet<User> user { get; set; }
     }
 }

--- a/HaulageApplication/HaulageApp/HaulageApp.csproj
+++ b/HaulageApplication/HaulageApp/HaulageApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
         <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
@@ -13,7 +13,7 @@
         either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
         <!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
 
-        <OutputType>Exe</OutputType>
+        <OutputType Condition="'$(TargetFramework)' != 'net8.0'">Exe</OutputType>
         <RootNamespace>HaulageApp</RootNamespace>
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
@@ -57,6 +57,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="CommunityToolkit.Maui" Version="9.0.2" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.6.24327.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.6.24327.4" />
@@ -78,6 +79,12 @@
       <MauiXaml Update="Views\AllNotesPage.xaml">
         <SubType>Designer</SubType>
       </MauiXaml>
+      <MauiXaml Update="Views\LoginPage.xaml">
+        <SubType>Designer</SubType>
+      </MauiXaml>
+      <MauiXaml Update="Views\LoadingPage.xaml">
+        <SubType>Designer</SubType>
+      </MauiXaml>
     </ItemGroup>
 
     <ItemGroup>
@@ -91,6 +98,14 @@
       </Compile>
       <Compile Update="Views\AllNotesPage.xaml.cs">
         <DependentUpon>AllNotesPage.xaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Views\LoginPage.xaml.cs">
+        <DependentUpon>LoginPage.xaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Views\LoadingPage.xaml.cs">
+        <DependentUpon>LoadingPage.xaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
     </ItemGroup>

--- a/HaulageApplication/HaulageApp/MauiProgram.cs
+++ b/HaulageApplication/HaulageApp/MauiProgram.cs
@@ -5,6 +5,7 @@ using HaulageApp.ViewModels;
 using HaulageApp.Views;
 using Microsoft.Extensions.Configuration;
 using Microsoft.EntityFrameworkCore;
+using CommunityToolkit.Maui;
 
 namespace HaulageApp;
 
@@ -15,6 +16,7 @@ public static class MauiProgram
         var builder = MauiApp.CreateBuilder();
         builder
             .UseMauiApp<App>()
+            .UseMauiCommunityToolkit()
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -38,7 +40,10 @@ public static class MauiProgram
         
         builder.Services.AddSingleton<AllNotesViewModel>();
         builder.Services.AddTransient<NoteViewModel>();
-
+        
+        builder.Services.AddSingleton<LoginViewModel>();
+        builder.Services.AddTransient<LoginPage>();
+        
         builder.Services.AddSingleton<AllNotesPage>();
         builder.Services.AddTransient<NotePage>();
 

--- a/HaulageApplication/HaulageApp/Models/User.cs
+++ b/HaulageApplication/HaulageApp/Models/User.cs
@@ -1,0 +1,13 @@
+using SQLite;
+
+namespace HaulageApp.Models;
+
+public class User
+{
+    [PrimaryKey, AutoIncrement]
+    public int Id { get; set; }
+    public int Role { get; set; }
+    public string Email { get; set; }
+    public string Password { get; set; }
+    public string Status { get; set; }
+}

--- a/HaulageApplication/HaulageApp/Models/User.cs
+++ b/HaulageApplication/HaulageApp/Models/User.cs
@@ -1,11 +1,15 @@
-using SQLite;
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace HaulageApp.Models;
 
+[Table("user")]
+[PrimaryKey(nameof(Id))]
 public class User
 {
-    [PrimaryKey, AutoIncrement]
     public int Id { get; set; }
+    
+    [ForeignKey(nameof(Role))]
     public int Role { get; set; }
     public string Email { get; set; }
     public string Password { get; set; }

--- a/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
@@ -1,0 +1,41 @@
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using HaulageApp.Models;
+using HaulageApp.Data;
+using Microsoft.Extensions.Logging;
+
+namespace HaulageApp.ViewModels;
+
+public partial class LoginViewModel : ObservableObject
+{
+    private readonly HaulageDbContext _context;
+    
+    public LoginViewModel(HaulageDbContext dbContext)
+    { 
+        _context = dbContext;
+    }
+    
+    public string Email { get; set; }
+    public string Password { get; set; }
+    
+    [RelayCommand]
+    private async Task Login()
+    {
+        if (IsCredentialCorrect(Email, Password))
+        {
+            await Shell.Current.GoToAsync("///home");
+        }
+        else
+        {
+            await Shell.Current.DisplayAlert("Login failed", "Username or password is incorrect", "Try again");
+        }
+    }
+    
+    public bool IsCredentialCorrect(string username, string password)
+    {
+        User? user =  _context.user
+             .AsQueryable()
+             .FirstOrDefault(user => user.Email == username.ToLower() && user.Password == password);
+        return user != null;
+    }
+}

--- a/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
@@ -9,33 +9,48 @@ namespace HaulageApp.ViewModels;
 public partial class LoginViewModel : ObservableObject
 {
     private readonly HaulageDbContext _context;
-    
+
     public LoginViewModel(HaulageDbContext dbContext)
-    { 
+    {
         _context = dbContext;
     }
-    
-    public string Email { get; set; }
-    public string Password { get; set; }
-    
+
+    public string Email { get; set; } = "";
+    public string Password { get; set; } = "";
+
     [RelayCommand]
     private async Task Login()
     {
-        if (IsCredentialCorrect(Email, Password))
+        var isCredentialCorrect = false;
+        var connected = true;
+
+        try
         {
-            await Shell.Current.GoToAsync("///home");
+            isCredentialCorrect = IsCredentialCorrect(Email, Password);
         }
-        else
+        catch (Exception e)
         {
-            await Shell.Current.DisplayAlert("Login failed", "Username or password is incorrect", "Try again");
+            Console.WriteLine(e);
+            connected = false;
+            await Shell.Current.DisplayAlert("Login failed", "Ensure you are connected to the internet", "Try again");
+        }
+
+        switch (isCredentialCorrect)
+        {
+            case true:
+                await Shell.Current.GoToAsync("///home");
+                break;
+            case false when connected:
+                await Shell.Current.DisplayAlert("Login failed", "Username or password is incorrect", "Try again");
+                break;
         }
     }
-    
+
     public bool IsCredentialCorrect(string username, string password)
     {
-        User? user =  _context.user
-             .AsQueryable()
-             .FirstOrDefault(user => user.Email == username.ToLower() && user.Password == password);
+        User? user = _context.user
+            .AsQueryable()
+            .FirstOrDefault(user => user.Email == username.ToLower() && user.Password == password);
         return user != null;
     }
 }

--- a/HaulageApplication/HaulageApp/Views/AllNotesPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/AllNotesPage.xaml
@@ -1,10 +1,14 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:viewModels="clr-namespace:HaulageApp.ViewModels"
              x:Class="HaulageApp.Views.AllNotesPage"
              Title="Your HaulageApp"
              NavigatedTo="ContentPage_NavigatedTo">
 
+    <!-- Disable the back button -->
+    <Shell.BackButtonBehavior>
+        <BackButtonBehavior IsEnabled="False" IsVisible="False"/>
+    </Shell.BackButtonBehavior>
+    
     <!-- Add an item to the toolbar -->
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="Add" Command="{Binding NewCommand}" IconImageSource="{FontImage Glyph='+', Color=Black, Size=22}" />

--- a/HaulageApplication/HaulageApp/Views/LoadingPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/LoadingPage.xaml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:mct="clr-namespace:CommunityToolkit.Maui.Behaviors;assembly=CommunityToolkit.Maui"
+             x:Class="HaulageApp.Views.LoadingPage"
+             Shell.NavBarIsVisible="False"
+             Title="LoadingPage">
+    <ContentPage.Behaviors>
+        <mct:StatusBarBehavior StatusBarColor="{StaticResource Tertiary}"/>
+    </ContentPage.Behaviors>
+    <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center">
+        <ActivityIndicator Color="{StaticResource Primary}"
+                           IsRunning="True" HeightRequest="50" WidthRequest="50"
+                           IsVisible="True" />
+        <Label Text="Checking authentication..." HorizontalOptions="Center" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/LoadingPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/LoadingPage.xaml.cs
@@ -1,0 +1,31 @@
+using HaulageApp.ViewModels;
+
+namespace HaulageApp.Views;
+
+public partial class LoadingPage : ContentPage
+{
+    public LoadingPage()
+    {
+        InitializeComponent();
+
+    }
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        if (await IsAuthenticated())
+        {
+            await Shell.Current.GoToAsync("///home");
+        }
+        else
+        {
+            await Shell.Current.GoToAsync("login");
+        }
+        base.OnNavigatedTo(args);
+    }
+
+    async Task<bool> IsAuthenticated()
+    {
+        // We would actually have a method to check authentication state.
+        // E.g. would provide a token or, even, can save in local storage
+        return false;
+    }
+}

--- a/HaulageApplication/HaulageApp/Views/LoginPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/LoginPage.xaml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HaulageApp.Views.LoginPage"
+             Shell.NavBarIsVisible="False"
+             Title="LoginPage">
+    <Grid RowDefinitions="2*,*" Margin="0,10,0,0">
+        <VerticalStackLayout Padding="10" VerticalOptions="Center" HorizontalOptions="Center">
+            <Frame BorderColor="Gray"
+               CornerRadius="10"
+               HasShadow="True"
+               Margin="0,-20,0,0"
+               ZIndex="0"
+               Padding="8">
+                <Frame.Shadow>
+                    <Shadow Brush="Black"
+                Offset="20,20"
+                Radius="10"
+                Opacity="0.9" />
+                </Frame.Shadow>
+                <StackLayout Padding="10">
+                    <VerticalStackLayout Padding="10" BackgroundColor="{StaticResource White}">
+                        <Image
+                Source="brushfill.png"
+                SemanticProperties.Description="Cute dot net bot waving hi to you!"
+                HeightRequest="80"
+                    IsVisible="False"
+                HorizontalOptions="Center" />
+                        <Label Text="Login"
+                       FontSize="30"
+                       FontAttributes="Bold"
+                       TextColor="Black"
+                       FontFamily="Consolas"
+                       Padding="5"/>
+                    </VerticalStackLayout>
+                    
+                    <VerticalStackLayout Padding="10">
+                        <Label FontFamily="Consolas" Text="Username"/>
+                        <Frame CornerRadius="10" Padding="3" Margin="0,10,0,0">
+                            <VerticalStackLayout>
+
+                                <Entry x:Name="Username" Text="{Binding Email}" Margin="5,0,0,0" Placeholder="Username" FontSize="18">
+                                </Entry>
+
+                            </VerticalStackLayout>
+                        </Frame>
+                        <VerticalStackLayout Padding="0" Margin="0,5,0,0">
+                            <Label FontFamily="Consolas" Text="Password"/>
+                            <Frame CornerRadius="10" Padding="3" Margin="0,10,0,0">
+                                <Entry x:Name="Password" Text="{Binding Password}" Margin="5,0,0,0" Placeholder="Password"
+                                   IsPassword="True" FontSize="18">
+                                </Entry>
+                            </Frame>
+                        </VerticalStackLayout>
+
+
+                        <Button Margin="0,20,0,0"
+                                x:Name="LoginButton"
+                                Text="Login" VerticalOptions="CenterAndExpand" 
+                                HorizontalOptions="FillAndExpand"
+                                Command="{Binding LoginCommand}"/>
+
+                        <BoxView Color="Black"
+                                 Margin="0,20,0,0"
+                                 HeightRequest="2"
+                                 HorizontalOptions="Fill" />
+                        <VerticalStackLayout Padding="10" Margin="0,10,0,0">
+                            <Label HorizontalOptions="Center"
+                                FontAttributes="Bold"
+                                FontFamily="Consolas">
+                                <Label.FormattedText>
+                                    <FormattedString>
+                                        <Span FontFamily="Consolas" FontAttributes="Bold" Text="Don't have an account? "/>
+                                        <Span FontFamily="Consolas" FontAttributes="Bold" Text="Sign Up"
+                  TextColor="{StaticResource Primary}"
+                  TextDecorations="Underline">
+                                            <Span.GestureRecognizers>
+                                                <TapGestureRecognizer Command="{Binding ValidateCommand}"
+                                          CommandParameter="https://learn.microsoft.com/dotnet/maui/" />
+                                            </Span.GestureRecognizers>
+                                        </Span>
+                                    </FormattedString>
+                                </Label.FormattedText>
+                            </Label>
+                            <Label Text="{Binding IsButtonEnabled}"/>
+                        </VerticalStackLayout>
+
+                    </VerticalStackLayout>
+                </StackLayout>
+            </Frame>
+        </VerticalStackLayout>
+    </Grid>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/LoginPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/LoginPage.xaml
@@ -40,7 +40,7 @@
                         <Frame CornerRadius="10" Padding="3" Margin="0,10,0,0">
                             <VerticalStackLayout>
 
-                                <Entry x:Name="Username" Text="{Binding Email}" Margin="5,0,0,0" Placeholder="Username" FontSize="18">
+                                <Entry x:Name="Email" Text="{Binding Email}" Margin="5,0,0,0" Placeholder="Email" FontSize="18">
                                 </Entry>
 
                             </VerticalStackLayout>

--- a/HaulageApplication/HaulageApp/Views/LoginPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/LoginPage.xaml.cs
@@ -1,0 +1,12 @@
+using HaulageApp.ViewModels;
+
+namespace HaulageApp.Views;
+
+public partial class LoginPage : ContentPage
+{
+    public LoginPage(LoginViewModel viewModel)
+    {
+        BindingContext = viewModel;
+        InitializeComponent();
+    }
+}

--- a/HaulageApplication/HaulageApp/Views/NotePage.xaml
+++ b/HaulageApplication/HaulageApp/Views/NotePage.xaml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:viewModels="clr-namespace:HaulageApp.ViewModels"
              x:Class="HaulageApp.Views.NotePage"
              Title="Note">
     <VerticalStackLayout Spacing="10" Margin="5">

--- a/HaulageApplication/HaulageAppTests/CredentialsTest.cs
+++ b/HaulageApplication/HaulageAppTests/CredentialsTest.cs
@@ -1,0 +1,57 @@
+using HaulageApp.Data;
+using Microsoft.EntityFrameworkCore;
+using HaulageApp.Models;
+using HaulageApp.ViewModels;
+
+namespace HaulageAppTests;
+
+public class CredentialsTest
+{
+    public DbContextOptions CreateContextOptions()
+    {
+        var options = new DbContextOptionsBuilder<HaulageDbContext>()
+            .UseInMemoryDatabase(databaseName: "MockDB")
+            .Options;
+
+        return options;
+    }
+
+    public void CreateContext(DbContextOptions options)
+    {
+        // Insert seed data into the database using one instance of the context
+        using var context = new HaulageDbContext(options);
+        context.AddRange(
+            new User { Email = "customer", Password = "1234", Status = "active", Role = 1 },
+            new User { Email = "admin", Password = "1234", Status = "inactive", Role = 3 }
+        );
+        context.SaveChanges();
+    }
+    
+    [Fact]
+    public void CredentialsReturnsTrueWhenDataExists()
+    {
+        var options = CreateContextOptions();
+        
+        CreateContext(options);
+        
+        using (var context = new HaulageDbContext(options))
+        {
+            var viewmodel = new LoginViewModel(context);
+            Assert.True(viewmodel.IsCredentialCorrect("customer", "1234"));
+        }
+    }
+    
+    [Fact]
+    public void CredentialsReturnsFalseWhenDataDoesNotExist()
+    {
+        var options = CreateContextOptions();
+        
+        CreateContext(options);
+        
+        using (var context = new HaulageDbContext(options))
+        {
+            var viewmodel = new LoginViewModel(context);
+            Assert.False(viewmodel.IsCredentialCorrect("who", "1234"));
+        }
+    }
+}

--- a/HaulageApplication/HaulageAppTests/HaulageAppTests.csproj
+++ b/HaulageApplication/HaulageAppTests/HaulageAppTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.7.24405.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+    
+    <ItemGroup>
+        <ProjectReference Include="../HaulageApp/HaulageApp.csproj"/>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Resolves #36 

- an ~existing user (in the database) can now log in to the app. The "new sign up" flow is there but currently disabled, as this is outside the scope of this issue
- used https://www.c-sharpcorner.com/blogs/building-a-login-flow-with-net-maui as a reference for the login 
- I added tests for the credentials check method, with an in memory mocked database
- also tested the full flow using iOS 17 (iPhone 15) on the simulator
- as mentioned in the code, currently the authentication is currently not persisted. This means users have to log in every time they use the app. I believe this is usually done with an authentication token. We could do it using some kind of local storage, but for iOS this apparently requires a paid developer account hence why this hasn't been done
- since this is for demonstration purposes I think this is enough to close this issue, if we want / need to persist the auth, we can add a separate issue 