### PR TITLE
[#37] Add a settings page with the ability to log out of a session

### DIFF
--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -30,5 +30,12 @@
                 ContentTemplate="{DataTemplate views:AboutPage}"
                 Route="about"/>
         </Tab>
+        
+        <Tab Title="Settings" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
+            <ShellContent
+                Title="Settings"
+                ContentTemplate="{DataTemplate views:SettingsPage}"
+                Route="settings"/>
+        </Tab>
     </TabBar>
 </Shell>

--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -11,5 +11,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("home", typeof(AllNotesPage));
         Routing.RegisterRoute("login", typeof(LoginPage));
         Routing.RegisterRoute(nameof(NotePage), typeof(NotePage));
+        Routing.RegisterRoute("settings", typeof(SettingsPage));
     }
 }

--- a/HaulageApplication/HaulageApp/HaulageApp.csproj
+++ b/HaulageApplication/HaulageApp/HaulageApp.csproj
@@ -85,6 +85,9 @@
       <MauiXaml Update="Views\LoadingPage.xaml">
         <SubType>Designer</SubType>
       </MauiXaml>
+      <MauiXaml Update="Views\SettingsPage.xaml">
+        <SubType>Designer</SubType>
+      </MauiXaml>
     </ItemGroup>
 
     <ItemGroup>
@@ -106,6 +109,10 @@
       </Compile>
       <Compile Update="Views\LoadingPage.xaml.cs">
         <DependentUpon>LoadingPage.xaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Views\SettingsPage.xaml.cs">
+        <DependentUpon>Settings.xaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
     </ItemGroup>

--- a/HaulageApplication/HaulageApp/Platforms/MacCatalyst/Entitlements.plist
+++ b/HaulageApplication/HaulageApp/Platforms/MacCatalyst/Entitlements.plist
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <!-- See https://aka.ms/maui-publish-app-store#add-entitlements for more information about adding entitlements.-->
-    <dict>
-        <!-- App Sandbox must be enabled to distribute a MacCatalyst app through the Mac App Store. -->
-        <key>com.apple.security.app-sandbox</key>
-        <true/>
-        <!-- When App Sandbox is enabled, this value is required to open outgoing network connections. -->
-        <key>com.apple.security.network.client</key>
-        <true/>
-    </dict>
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>com.companyname.haulage</string>
+	</array>
+</dict>
 </plist>
-

--- a/HaulageApplication/HaulageApp/Platforms/iOS/Entitlements.plist
+++ b/HaulageApplication/HaulageApp/Platforms/iOS/Entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>keychain-access-groups</key>
+        <array>
+        <string>$(AppIdentifierPrefix)com.companyname.haulage</string>
+        </array>
+    </dict>
+</plist>  

--- a/HaulageApplication/HaulageApp/Platforms/iOS/Info.plist
+++ b/HaulageApplication/HaulageApp/Platforms/iOS/Info.plist
@@ -28,5 +28,7 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/appicon.appiconset</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.companyname.haulage</string>
 </dict>
 </plist>

--- a/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
@@ -38,6 +38,7 @@ public partial class LoginViewModel : ObservableObject
         switch (isCredentialCorrect)
         {
             case true:
+                await SecureStorage.SetAsync("hasAuth", Email);
                 await Shell.Current.GoToAsync("///home");
                 break;
             case false when connected:

--- a/HaulageApplication/HaulageApp/Views/LoadingPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/LoadingPage.xaml.cs
@@ -24,8 +24,7 @@ public partial class LoadingPage : ContentPage
 
     async Task<bool> IsAuthenticated()
     {
-        // We would actually have a method to check authentication state.
-        // E.g. would provide a token or, even, can save in local storage
-        return false;
+        var hasAuth = await SecureStorage.GetAsync("hasAuth");
+        return hasAuth != null;
     }
 }

--- a/HaulageApplication/HaulageApp/Views/SettingsPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/SettingsPage.xaml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HaulageApp.Views.SettingsPage"
+             Title="Settings">
+   <Grid RowDefinitions="2*,*" Margin="0,10,0,0">
+        <VerticalStackLayout Padding="10" VerticalOptions="Center" HorizontalOptions="Center">
+            <Frame BorderColor="Gray"
+               CornerRadius="10"
+               HasShadow="True"
+               Margin="0,-20,0,0"
+               ZIndex="0"
+               Padding="8">
+                <Frame.Shadow>
+                    <Shadow Brush="Black"
+                Offset="20,20"
+                Radius="10"
+                Opacity="0.9" />
+                </Frame.Shadow>
+                <StackLayout Padding="10">
+
+                    <VerticalStackLayout Padding="10">
+
+                        <VerticalStackLayout Padding="0" Margin="0,5,0,0">
+                            <Label
+                                Text="Your are currently logged in."
+                                FontSize="16"
+                                />
+                            <BoxView Color="Black"
+                                 Margin="0,20,0,0"
+                                 HeightRequest="2"
+                                 HorizontalOptions="Fill" />
+                            <Button
+                                Margin="0,20,0,0"
+                                Text="Logout"
+                                x:Name="LogoutButton"
+                                Clicked="LogoutButton_Clicked"
+                                />
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </StackLayout>
+            </Frame>
+        </VerticalStackLayout>
+    </Grid>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/SettingsPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/SettingsPage.xaml.cs
@@ -1,0 +1,17 @@
+namespace HaulageApp.Views;
+
+public partial class SettingsPage : ContentPage
+{
+    public SettingsPage()
+    {
+        InitializeComponent();
+    }
+    
+    private async void LogoutButton_Clicked(object sender, EventArgs e)
+    {
+        if (await DisplayAlert("Are you sure?", "You will be logged out.", "Log out", "Cancel"))
+        {
+            await Shell.Current.GoToAsync("///login");
+        }
+    }
+}

--- a/HaulageApplication/HaulageApp/Views/SettingsPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/SettingsPage.xaml.cs
@@ -11,6 +11,7 @@ public partial class SettingsPage : ContentPage
     {
         if (await DisplayAlert("Are you sure?", "You will be logged out.", "Log out", "Cancel"))
         {
+            SecureStorage.Remove("hasAuth");
             await Shell.Current.GoToAsync("///login");
         }
     }


### PR DESCRIPTION
Resolves #37 

If you are already logged in, a settings page has been added to the tabs where you can log out which takes you back to the log in screen. 

Not proper auth, but also fixed the secure storage issue by adding an Entitlements.plist file, so we can save the user logged in status for the session. This means the session now lasts even if you quit the app, until you log out.

Showing, and option to amend, account details (e.g. password) will be addressed in next issue (#38 )

Full flow tested using iOS 17 iPhone 15 simulator. Screenshots below

<img width="473" alt="Screenshot 2024-08-16 at 17 25 17" src="https://github.com/user-attachments/assets/db092bec-d694-408e-8e21-9910657b4c2b">
<img width="467" alt="Screenshot 2024-08-16 at 17 25 28" src="https://github.com/user-attachments/assets/61b1e9cc-851f-453a-8cf9-3eb7b6e9c11a">

No unit tests added since I only use a _clicked method.
Used this for reference: https://www.c-sharpcorner.com/blogs/building-a-login-flow-with-net-maui