### PR TITLE
 [#38] Enable a user to change their password 

### DIFF
--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <Shell
     x:Class="HaulageApp.AppShell"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:views="clr-namespace:HaulageApp.Views"
     FlyoutBehavior="Disabled">
-    
+
     <ShellContent
         Title="Loading"
         ContentTemplate="{DataTemplate views:LoadingPage}"
@@ -14,34 +15,39 @@
     <ShellContent
         Title="Login"
         ContentTemplate="{DataTemplate views:LoginPage}"
-        Route="login"/>
-    
+        Route="login" />
+
     <TabBar>
-        <Tab Title="Home" Icon="{OnPlatform 'icon_notes.png', iOS='icon_notes_ios.png', MacCatalyst='icon_notes_ios.png'}">
+        <Tab Title="Home"
+             Icon="{OnPlatform 'icon_notes.png', iOS='icon_notes_ios.png', MacCatalyst='icon_notes_ios.png'}">
             <ShellContent
                 Title="Home"
                 ContentTemplate="{DataTemplate views:AllNotesPage}"
-                Route="home"/>
+                Route="home" />
         </Tab>
-        
-        <Tab Title="About" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
+
+        <Tab Title="About"
+             Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
             <ShellContent
                 Title="About"
                 ContentTemplate="{DataTemplate views:AboutPage}"
-                Route="about"/>
+                Route="about" />
         </Tab>
-      
-       <Tab Title="Vehicles" Icon="{OnPlatform 'icon_notes.png', iOS='icon_notes_ios.png', MacCatalyst='icon_notes_ios.png'}">
+
+        <Tab Title="Vehicles"
+             Icon="{OnPlatform 'icon_notes.png', iOS='icon_notes_ios.png', MacCatalyst='icon_notes_ios.png'}">
             <ShellContent
                 Title="Vehicle"
                 ContentTemplate="{DataTemplate views:AllVehiclesPage}"
-                Route="vehicles"/>
+                Route="vehicles" />
         </Tab>
-        
-        <Tab Title="Settings" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
+
+        <Tab Title="Settings"
+             Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
             <ShellContent
                 Title="Settings"
                 ContentTemplate="{DataTemplate views:SettingsPage}"
-                Route="settings"/> 
+                Route="settings" />
+        </Tab>
     </TabBar>
 </Shell>

--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -30,5 +30,12 @@
                 ContentTemplate="{DataTemplate views:AboutPage}"
                 Route="about"/>
         </Tab>
+        
+        <Tab Title="Settings" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
+            <ShellContent
+                Title="Settings"
+                ContentTemplate="{DataTemplate views:SettingsPage}"
+                Route="settings"/>
+        </Tab>
     </TabBar>
 </Shell>

--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -11,5 +11,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("home", typeof(AllNotesPage));
         Routing.RegisterRoute("login", typeof(LoginPage));
         Routing.RegisterRoute(nameof(NotePage), typeof(NotePage));
+        Routing.RegisterRoute("settings", typeof(SettingsPage));
     }
 }

--- a/HaulageApplication/HaulageApp/Common/ISecureStorageWrapper.cs
+++ b/HaulageApplication/HaulageApp/Common/ISecureStorageWrapper.cs
@@ -1,0 +1,8 @@
+namespace HaulageApp.Common;
+
+public interface ISecureStorageWrapper
+{
+    Task<string?> GetAsync(string key);
+
+    Task SetAsync(string key, string value);
+}

--- a/HaulageApplication/HaulageApp/Common/SecureStorageWrapper.cs
+++ b/HaulageApplication/HaulageApp/Common/SecureStorageWrapper.cs
@@ -1,0 +1,14 @@
+namespace HaulageApp.Common;
+
+public class SecureStorageWrapper: ISecureStorageWrapper
+{
+    public Task<string?> GetAsync(string key)
+    {
+        return SecureStorage.GetAsync(key);
+    }
+
+    public Task SetAsync(string key, string value)
+    {
+        return SecureStorage.SetAsync(key, value);
+    }
+}

--- a/HaulageApplication/HaulageApp/HaulageApp.csproj
+++ b/HaulageApplication/HaulageApp/HaulageApp.csproj
@@ -85,6 +85,9 @@
       <MauiXaml Update="Views\LoadingPage.xaml">
         <SubType>Designer</SubType>
       </MauiXaml>
+      <MauiXaml Update="Views\SettingsPage.xaml">
+        <SubType>Designer</SubType>
+      </MauiXaml>
     </ItemGroup>
 
     <ItemGroup>
@@ -106,6 +109,10 @@
       </Compile>
       <Compile Update="Views\LoadingPage.xaml.cs">
         <DependentUpon>LoadingPage.xaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Views\SettingsPage.xaml.cs">
+        <DependentUpon>Settings.xaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
     </ItemGroup>

--- a/HaulageApplication/HaulageApp/MauiProgram.cs
+++ b/HaulageApplication/HaulageApp/MauiProgram.cs
@@ -6,6 +6,7 @@ using HaulageApp.Views;
 using Microsoft.Extensions.Configuration;
 using Microsoft.EntityFrameworkCore;
 using CommunityToolkit.Maui;
+using HaulageApp.Common;
 
 namespace HaulageApp;
 
@@ -37,9 +38,14 @@ public static class MauiProgram
             throw new ApplicationException("LocalConnection is not set");
         
         builder.Services.AddDbContext<HaulageDbContext>(options => options.UseSqlServer(connectionString));
-        
+
+        builder.Services.AddSingleton<ISecureStorageWrapper>(implementationFactory => new SecureStorageWrapper());
+                    
         builder.Services.AddSingleton<AllNotesViewModel>();
         builder.Services.AddTransient<NoteViewModel>();
+        
+        builder.Services.AddSingleton<SettingsViewModel>();
+        builder.Services.AddTransient<SettingsPage>();
         
         builder.Services.AddSingleton<LoginViewModel>();
         builder.Services.AddTransient<LoginPage>();

--- a/HaulageApplication/HaulageApp/Platforms/MacCatalyst/Entitlements.plist
+++ b/HaulageApplication/HaulageApp/Platforms/MacCatalyst/Entitlements.plist
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <!-- See https://aka.ms/maui-publish-app-store#add-entitlements for more information about adding entitlements.-->
-    <dict>
-        <!-- App Sandbox must be enabled to distribute a MacCatalyst app through the Mac App Store. -->
-        <key>com.apple.security.app-sandbox</key>
-        <true/>
-        <!-- When App Sandbox is enabled, this value is required to open outgoing network connections. -->
-        <key>com.apple.security.network.client</key>
-        <true/>
-    </dict>
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>com.companyname.haulage</string>
+	</array>
+</dict>
 </plist>
-

--- a/HaulageApplication/HaulageApp/Platforms/iOS/Entitlements.plist
+++ b/HaulageApplication/HaulageApp/Platforms/iOS/Entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>keychain-access-groups</key>
+        <array>
+        <string>$(AppIdentifierPrefix)com.companyname.haulage</string>
+        </array>
+    </dict>
+</plist>  

--- a/HaulageApplication/HaulageApp/Platforms/iOS/Info.plist
+++ b/HaulageApplication/HaulageApp/Platforms/iOS/Info.plist
@@ -28,5 +28,7 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/appicon.appiconset</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.companyname.haulage</string>
 </dict>
 </plist>

--- a/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
@@ -38,6 +38,7 @@ public partial class LoginViewModel : ObservableObject
         switch (isCredentialCorrect)
         {
             case true:
+                await SecureStorage.SetAsync("hasAuth", Email);
                 await Shell.Current.GoToAsync("///home");
                 break;
             case false when connected:

--- a/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
@@ -2,7 +2,6 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using HaulageApp.Models;
 using HaulageApp.Data;
-using Microsoft.Extensions.Logging;
 
 namespace HaulageApp.ViewModels;
 

--- a/HaulageApplication/HaulageApp/ViewModels/SettingsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,111 @@
+using System.Text.RegularExpressions;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using HaulageApp.Common;
+using HaulageApp.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace HaulageApp.ViewModels;
+
+public partial class SettingsViewModel : ObservableObject
+{
+    private readonly HaulageDbContext _context;
+    private readonly ISecureStorageWrapper _storageWrapper;
+
+    public SettingsViewModel(HaulageDbContext dbContext, ISecureStorageWrapper storageWrapper)
+    {
+        _context = dbContext;
+        _storageWrapper = storageWrapper;
+        GetEmail();
+    }
+
+    private string? _email;
+    public string Email
+    {
+        get => _email ?? "";
+        set
+        {
+            _email = value;
+            OnPropertyChanged(Email);
+        }
+    }
+
+    private async Task GetEmail()
+    {
+        Email = await _storageWrapper.GetAsync("hasAuth") ?? "Error retrieving email.";
+    }
+
+    [RelayCommand]
+    private async Task ChangePassword()
+    {
+        var newPassword = await Shell.Current.DisplayPromptAsync("Update Password", "Enter new password");
+        
+        if (newPassword == null)
+        {
+            return;
+        }
+
+        while (!PasswordIsValid(newPassword))
+        {
+            newPassword = await Shell.Current.DisplayPromptAsync("Error", "Choose a valid password");
+        }
+        
+        if (UpdateIsSuccessful(Email, newPassword))
+        {
+            await Shell.Current.DisplayAlert("", "Update successful", "OK");
+        }
+        else
+        {
+            await Shell.Current.DisplayAlert("","Something went wrong, try again.", "OK");
+        }
+    }
+
+    private bool UpdateIsSuccessful(string email, string newPassword)
+    {
+        try
+        {
+           _context.user
+                .AsQueryable()
+                .Where(user => user.Email == email)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(user => user.Password, user => newPassword));
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            return false;
+        }
+        return true;
+    }
+
+    [RelayCommand]
+    private async Task Logout()
+    {
+        if (await Shell.Current.DisplayAlert("", "Log out of your account?", "Log out", "Cancel"))
+        {
+            SecureStorage.Remove("hasAuth");
+            await Shell.Current.GoToAsync("///login");
+        }
+    }
+
+    public bool PasswordIsValid(string? password)
+    {
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            return false;
+        }
+
+        // a pattern that may protect against sql injection, 
+        // but this should be done on the server side
+        const string pattern = @"[\s]*((delete)|(exec)|(drop\s*table)|(insert)|(shutdown)|(update)|(\bor\b))";
+        Regex regex = new Regex(pattern, RegexOptions.IgnoreCase);
+        if (regex.Match(password).Success)
+        {
+            return false;
+        }
+
+        // You could look/check for more.
+        // e.g. at least x characters, include upper lower case, numbers, including special characters.
+        return password.Trim().Length >= 6;
+    }
+}

--- a/HaulageApplication/HaulageApp/ViewModels/SettingsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/SettingsViewModel.cs
@@ -39,7 +39,7 @@ public partial class SettingsViewModel : ObservableObject
     private async Task ChangePassword()
     {
         var newPassword = await Shell.Current.DisplayPromptAsync("Update Password", "Enter new password");
-        
+        // Result of "cancel" is null.
         if (newPassword == null)
         {
             return;
@@ -48,6 +48,11 @@ public partial class SettingsViewModel : ObservableObject
         while (!PasswordIsValid(newPassword))
         {
             newPassword = await Shell.Current.DisplayPromptAsync("Error", "Choose a valid password");
+            // Result of "cancel" is null.
+            if (newPassword == null)
+            {
+                return;
+            }
         }
         
         if (UpdateIsSuccessful(Email, newPassword))
@@ -90,11 +95,6 @@ public partial class SettingsViewModel : ObservableObject
 
     public bool PasswordIsValid(string? password)
     {
-        if (string.IsNullOrWhiteSpace(password))
-        {
-            return false;
-        }
-
         // a pattern that may protect against sql injection, 
         // but this should be done on the server side
         const string pattern = @"[\s]*((delete)|(exec)|(drop\s*table)|(insert)|(shutdown)|(update)|(\bor\b))";

--- a/HaulageApplication/HaulageApp/Views/LoadingPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/LoadingPage.xaml.cs
@@ -24,8 +24,7 @@ public partial class LoadingPage : ContentPage
 
     async Task<bool> IsAuthenticated()
     {
-        // We would actually have a method to check authentication state.
-        // E.g. would provide a token or, even, can save in local storage
-        return false;
+        var hasAuth = await SecureStorage.GetAsync("hasAuth");
+        return hasAuth != null;
     }
 }

--- a/HaulageApplication/HaulageApp/Views/SettingsPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/SettingsPage.xaml
@@ -4,43 +4,46 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="HaulageApp.Views.SettingsPage"
              Title="Settings">
-   <Grid RowDefinitions="2*,*" Margin="0,10,0,0">
+    <Grid RowDefinitions="2*,*" Margin="0,10,0,0">
         <VerticalStackLayout Padding="10" VerticalOptions="Center" HorizontalOptions="Center">
-            <Frame BorderColor="Gray"
-               CornerRadius="10"
-               HasShadow="True"
-               Margin="0,-20,0,0"
-               ZIndex="0"
-               Padding="8">
-                <Frame.Shadow>
-                    <Shadow Brush="Black"
-                Offset="20,20"
-                Radius="10"
-                Opacity="0.9" />
-                </Frame.Shadow>
                 <StackLayout Padding="10">
 
-                    <VerticalStackLayout Padding="10">
+                    <VerticalStackLayout>
+                        <Label Text="Email"
+                               FontAttributes="Bold"
+                               FontSize="10"/>
+                        <Label Text="{Binding Email}"
+                               FontSize="16"
+                               Padding="10"/>
+                    </VerticalStackLayout>
 
-                        <VerticalStackLayout Padding="0" Margin="0,5,0,0">
-                            <Label
-                                Text="Your are currently logged in."
-                                FontSize="16"
-                                />
-                            <BoxView Color="Black"
+                    <VerticalStackLayout>
+                        <Label Text="Password"
+                               FontAttributes="Bold"
+                               FontSize="10"
+                               Padding="0,10,0,10"/>
+                        <Button
+                            Text="Change password"
+                            FontSize="16"
+                            Padding="10"
+                            Command="{Binding ChangePasswordCommand}"/>
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout >
+
+                        <BoxView Color="Black"
                                  Margin="0,20,0,0"
                                  HeightRequest="2"
                                  HorizontalOptions="Fill" />
-                            <Button
-                                Margin="0,20,0,0"
-                                Text="Logout"
-                                x:Name="LogoutButton"
-                                Clicked="LogoutButton_Clicked"
-                                />
-                        </VerticalStackLayout>
+                        <Button
+                            Margin="0,20,0,0"
+                            Text="Logout"
+                            FontSize="16"
+                            x:Name="LogoutButton"
+                            Command="{Binding LogoutCommand}"
+                            Padding="10"/>
                     </VerticalStackLayout>
                 </StackLayout>
-            </Frame>
         </VerticalStackLayout>
     </Grid>
 </ContentPage>

--- a/HaulageApplication/HaulageApp/Views/SettingsPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/SettingsPage.xaml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HaulageApp.Views.SettingsPage"
+             Title="Settings">
+   <Grid RowDefinitions="2*,*" Margin="0,10,0,0">
+        <VerticalStackLayout Padding="10" VerticalOptions="Center" HorizontalOptions="Center">
+            <Frame BorderColor="Gray"
+               CornerRadius="10"
+               HasShadow="True"
+               Margin="0,-20,0,0"
+               ZIndex="0"
+               Padding="8">
+                <Frame.Shadow>
+                    <Shadow Brush="Black"
+                Offset="20,20"
+                Radius="10"
+                Opacity="0.9" />
+                </Frame.Shadow>
+                <StackLayout Padding="10">
+
+                    <VerticalStackLayout Padding="10">
+
+                        <VerticalStackLayout Padding="0" Margin="0,5,0,0">
+                            <Label
+                                Text="Your are currently logged in."
+                                FontSize="16"
+                                />
+                            <BoxView Color="Black"
+                                 Margin="0,20,0,0"
+                                 HeightRequest="2"
+                                 HorizontalOptions="Fill" />
+                            <Button
+                                Margin="0,20,0,0"
+                                Text="Logout"
+                                x:Name="LogoutButton"
+                                Clicked="LogoutButton_Clicked"
+                                />
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </StackLayout>
+            </Frame>
+        </VerticalStackLayout>
+    </Grid>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/SettingsPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/SettingsPage.xaml.cs
@@ -1,0 +1,17 @@
+namespace HaulageApp.Views;
+
+public partial class SettingsPage : ContentPage
+{
+    public SettingsPage()
+    {
+        InitializeComponent();
+    }
+    
+    private async void LogoutButton_Clicked(object sender, EventArgs e)
+    {
+        if (await DisplayAlert("Are you sure?", "You will be logged out.", "Log out", "Cancel"))
+        {
+            await Shell.Current.GoToAsync("///login");
+        }
+    }
+}

--- a/HaulageApplication/HaulageApp/Views/SettingsPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/SettingsPage.xaml.cs
@@ -11,6 +11,7 @@ public partial class SettingsPage : ContentPage
     {
         if (await DisplayAlert("Are you sure?", "You will be logged out.", "Log out", "Cancel"))
         {
+            SecureStorage.Remove("hasAuth");
             await Shell.Current.GoToAsync("///login");
         }
     }

--- a/HaulageApplication/HaulageApp/Views/SettingsPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/SettingsPage.xaml.cs
@@ -1,18 +1,12 @@
+using HaulageApp.ViewModels;
+
 namespace HaulageApp.Views;
 
 public partial class SettingsPage : ContentPage
 {
-    public SettingsPage()
+    public SettingsPage(SettingsViewModel viewModel)
     {
+        BindingContext = viewModel;
         InitializeComponent();
-    }
-    
-    private async void LogoutButton_Clicked(object sender, EventArgs e)
-    {
-        if (await DisplayAlert("Are you sure?", "You will be logged out.", "Log out", "Cancel"))
-        {
-            SecureStorage.Remove("hasAuth");
-            await Shell.Current.GoToAsync("///login");
-        }
     }
 }

--- a/HaulageApplication/HaulageAppTests/CredentialsTest.cs
+++ b/HaulageApplication/HaulageAppTests/CredentialsTest.cs
@@ -1,38 +1,18 @@
 using HaulageApp.Data;
-using Microsoft.EntityFrameworkCore;
-using HaulageApp.Models;
 using HaulageApp.ViewModels;
 
 namespace HaulageAppTests;
 
 public class CredentialsTest
 {
-    public DbContextOptions CreateContextOptions()
-    {
-        var options = new DbContextOptionsBuilder<HaulageDbContext>()
-            .UseInMemoryDatabase(databaseName: "MockDB")
-            .Options;
-
-        return options;
-    }
-
-    public void CreateContext(DbContextOptions options)
-    {
-        // Insert seed data into the database using one instance of the context
-        using var context = new HaulageDbContext(options);
-        context.AddRange(
-            new User { Email = "customer", Password = "1234", Status = "active", Role = 1 },
-            new User { Email = "admin", Password = "1234", Status = "inactive", Role = 3 }
-        );
-        context.SaveChanges();
-    }
+    private MockDb db = new();
     
     [Fact]
     public void CredentialsReturnsTrueWhenDataExists()
     {
-        var options = CreateContextOptions();
+        var options = db.CreateContextOptions();
         
-        CreateContext(options);
+        db.CreateContext(options);
         
         using (var context = new HaulageDbContext(options))
         {
@@ -44,9 +24,9 @@ public class CredentialsTest
     [Fact]
     public void CredentialsReturnsFalseWhenDataDoesNotExist()
     {
-        var options = CreateContextOptions();
+        var options = db.CreateContextOptions();
         
-        CreateContext(options);
+        db.CreateContext(options);
         
         using (var context = new HaulageDbContext(options))
         {

--- a/HaulageApplication/HaulageAppTests/FakeSecureStorageWrapper.cs
+++ b/HaulageApplication/HaulageAppTests/FakeSecureStorageWrapper.cs
@@ -1,0 +1,18 @@
+using HaulageApp.Common;
+
+namespace HaulageAppTests;
+
+public class FakeSecureStorageWrapper: ISecureStorageWrapper
+{
+    private readonly Dictionary < string, string > _secureStorage = new();
+    
+    public async Task<string?> GetAsync(string key)
+    {
+        return _secureStorage.GetValueOrDefault(key, null);
+    }
+
+    public async Task SetAsync(string key, string value)
+    {
+        _secureStorage[key] = value;
+    }
+}

--- a/HaulageApplication/HaulageAppTests/MockDb.cs
+++ b/HaulageApplication/HaulageAppTests/MockDb.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using HaulageApp.Models;
+using HaulageApp.Data;
+
+namespace HaulageAppTests;
+
+public class MockDb
+{
+    public DbContextOptions CreateContextOptions()
+    {
+        var options = new DbContextOptionsBuilder<HaulageDbContext>()
+            .UseInMemoryDatabase(databaseName: "MockDB")
+            .Options;
+
+        return options;
+    }
+
+    public void CreateContext(DbContextOptions options)
+    {
+        // Insert seed data into the database using one instance of the context
+        using var context = new HaulageDbContext(options);
+        //user table
+        context.user.Add(new User { Email = "customer", Password = "1234", Status = "active", Role = 1 });
+        context.user.Add(new User { Email = "driver", Password = "1234", Status = "inactive", Role = 2 });
+        context.user.Add(new User { Email = "admin", Password = "1234", Status = "active", Role = 3 });
+        context.SaveChanges();
+    }
+}

--- a/HaulageApplication/HaulageAppTests/UserSettingsTest.cs
+++ b/HaulageApplication/HaulageAppTests/UserSettingsTest.cs
@@ -9,7 +9,7 @@ public class UserSettingsTest
     private FakeSecureStorageWrapper fakeStorage = new();
 
     [Fact]
-    public async void UserEmailReturnsWhenHasAuth()
+    public async void ReturnsUserEmailWhenAuthenticated()
     {
         var options = db.CreateContextOptions();
         db.CreateContext(options);
@@ -23,7 +23,7 @@ public class UserSettingsTest
     }
 
     [Fact]
-    public void ErrorMessageReturnsWhenNoAuth()
+    public void ReturnsErrorMessageWhenNotAuthenticated()
     {
         var options = db.CreateContextOptions();
         db.CreateContext(options);
@@ -36,7 +36,7 @@ public class UserSettingsTest
     }
 
     [Fact]
-    public void ReturnTrueOnValidPassword()
+    public void ReturnsTrueForValidPassword()
     {
         var options = db.CreateContextOptions();
         db.CreateContext(options);
@@ -49,7 +49,7 @@ public class UserSettingsTest
     }
     
     [Fact]
-    public void ReturnFalseOnInvalidPassword()
+    public void ReturnsFalseForInvalidPassword()
     {
         var options = db.CreateContextOptions();
         db.CreateContext(options);

--- a/HaulageApplication/HaulageAppTests/UserSettingsTest.cs
+++ b/HaulageApplication/HaulageAppTests/UserSettingsTest.cs
@@ -1,0 +1,68 @@
+using HaulageApp.Data;
+using HaulageApp.ViewModels;
+
+namespace HaulageAppTests;
+
+public class UserSettingsTest
+{
+    private MockDb db = new();
+    private FakeSecureStorageWrapper fakeStorage = new();
+
+    [Fact]
+    public async void UserEmailReturnsWhenHasAuth()
+    {
+        var options = db.CreateContextOptions();
+        db.CreateContext(options);
+
+        using (var context = new HaulageDbContext(options))
+        {
+            await fakeStorage.SetAsync("hasAuth", "testEmail");
+            var viewmodel = new SettingsViewModel(context, fakeStorage);
+            Assert.Equal("testEmail", viewmodel.Email);
+        }
+    }
+
+    [Fact]
+    public void ErrorMessageReturnsWhenNoAuth()
+    {
+        var options = db.CreateContextOptions();
+        db.CreateContext(options);
+
+        using (var context = new HaulageDbContext(options))
+        {
+            var viewmodel = new SettingsViewModel(context, fakeStorage);
+            Assert.Equal("Error retrieving email.", viewmodel.Email);
+        }
+    }
+
+    [Fact]
+    public void ReturnTrueOnValidPassword()
+    {
+        var options = db.CreateContextOptions();
+        db.CreateContext(options);
+
+        using (var context = new HaulageDbContext(options))
+        {
+            var viewmodel = new SettingsViewModel(context, fakeStorage);
+            Assert.True(viewmodel.PasswordIsValid("123456"));
+        }
+    }
+    
+    [Fact]
+    public void ReturnFalseOnInvalidPassword()
+    {
+        var options = db.CreateContextOptions();
+        db.CreateContext(options);
+
+        using (var context = new HaulageDbContext(options))
+        {
+            var viewmodel = new SettingsViewModel(context, fakeStorage);
+            //empty
+            Assert.False(viewmodel.PasswordIsValid(""));
+            //potential injection
+            Assert.False(viewmodel.PasswordIsValid("10; DROP TABLE members /*"));
+            //too short
+            Assert.False(viewmodel.PasswordIsValid("1234"));
+        }
+    }
+}


### PR DESCRIPTION
Resolves #37 and #38 
Resolves #6 

If a user is logged in, they can navigate to settings where they can see their account details:
For now this is username (email) and they have the ability to manage their account by changing their password.

Some (not extensive) validation has been added to the password field, it needs to be longer than 6 letters.

Tested flow using iOS 17 iPhone 15 simulator. Unit tests have been added, although I could not add a test including the database update method, since this is not supported by the in memory database https://github.com/dotnet/efcore/issues/30185#issuecomment-1410959659

<img width="462" alt="Screenshot 2024-08-17 at 20 26 49" src="https://github.com/user-attachments/assets/b9dd4928-7883-4ba5-adc5-8b9461d32e80">
<img width="497" alt="Screenshot 2024-08-17 at 20 27 37" src="https://github.com/user-attachments/assets/54ca8f93-ad77-4571-bbaf-76388c63ce7a">
<img width="482" alt="Screenshot 2024-08-17 at 20 27 25" src="https://github.com/user-attachments/assets/9132aa85-26cf-4edf-8868-5186d55306d0">
<img width="515" alt="Screenshot 2024-08-17 at 20 27 05" src="https://github.com/user-attachments/assets/68a858d8-d1a1-4c72-9265-9ac3d863c553">
<img width="499" alt="Screenshot 2024-08-17 at 20 26 57" src="https://github.com/user-attachments/assets/a1e64f7f-e7a2-49e2-9e88-27587e25e36f">
