### PR TITLE
Adding Ability for Vehicles to be managed

### DIFF
--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -30,5 +30,12 @@
                 ContentTemplate="{DataTemplate views:AboutPage}"
                 Route="about"/>
         </Tab>
+        
+        <Tab Title="Vehicles" Icon="{OnPlatform 'icon_notes.png', iOS='icon_notes_ios.png', MacCatalyst='icon_notes_ios.png'}">
+            <ShellContent
+                Title="Vehicle"
+                ContentTemplate="{DataTemplate views:AllVehiclesPage}"
+                Route="vehicles"/>
+        </Tab>
     </TabBar>
 </Shell>

--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -10,6 +10,8 @@ public partial class AppShell : Shell
 
         Routing.RegisterRoute("home", typeof(AllNotesPage));
         Routing.RegisterRoute("login", typeof(LoginPage));
+        Routing.RegisterRoute("vehicles", typeof(AllVehiclesPage));
         Routing.RegisterRoute(nameof(NotePage), typeof(NotePage));
+        Routing.RegisterRoute(nameof(VehiclePage), typeof(VehiclePage));
     }
 }

--- a/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
+++ b/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
@@ -12,5 +12,6 @@ namespace HaulageApp.Data
 
         public DbSet<Note> note { get; set; }
         public DbSet<User> user { get; set; }
+        public DbSet<Vehicle> vehicle { get; set; }
     }
 }

--- a/HaulageApplication/HaulageApp/HaulageApp.csproj
+++ b/HaulageApplication/HaulageApp/HaulageApp.csproj
@@ -85,6 +85,12 @@
       <MauiXaml Update="Views\LoadingPage.xaml">
         <SubType>Designer</SubType>
       </MauiXaml>
+      <MauiXaml Update="Views\VehiclePage.xaml">
+        <SubType>Designer</SubType>
+      </MauiXaml>  
+      <MauiXaml Update="Views\AllVehiclesPage.xaml">
+        <SubType>Designer</SubType>
+      </MauiXaml>  
     </ItemGroup>
 
     <ItemGroup>
@@ -108,6 +114,14 @@
         <DependentUpon>LoadingPage.xaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
+      <Compile Update="Views\VehiclePage.xaml.cs">
+        <DependentUpon>VehiclePage.xaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Views\AllVehiclesPage.xaml.cs">
+        <DependentUpon>AllVehiclesPage.xaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>  
     </ItemGroup>
 
     <ItemGroup>

--- a/HaulageApplication/HaulageApp/MauiProgram.cs
+++ b/HaulageApplication/HaulageApp/MauiProgram.cs
@@ -46,6 +46,11 @@ public static class MauiProgram
         
         builder.Services.AddSingleton<AllNotesPage>();
         builder.Services.AddTransient<NotePage>();
+        
+        builder.Services.AddSingleton<AllVehiclesPage>();
+        builder.Services.AddTransient<VehiclePage>();
+        builder.Services.AddSingleton<AllVehiclesViewModel>();
+        builder.Services.AddTransient<VehicleViewModel>();
 
 #if DEBUG
         builder.Logging.AddDebug();

--- a/HaulageApplication/HaulageApp/Models/Vehicle.cs
+++ b/HaulageApplication/HaulageApp/Models/Vehicle.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace HaulageApp.Models;
+
+[Table("vehicle")]
+[PrimaryKey(nameof(Id))]
+public class Vehicle
+{
+    public int Id { get; set; }
+    public string Type { get; set; }
+    public int Capacity { get; set; }
+    public string Status { get; set; }
+    
+}

--- a/HaulageApplication/HaulageApp/ViewModels/AllVehiclesViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/AllVehiclesViewModel.cs
@@ -1,0 +1,97 @@
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using HaulageApp.Data;
+
+namespace HaulageApp.ViewModels;
+
+public class AllVehiclesViewModel: IQueryAttributable
+{
+    public ObservableCollection<VehicleViewModel> AllVehicles { get; }
+    public ICommand NewCommand { get; }
+    public ICommand SelectVehicleCommand { get; }
+
+    private readonly HaulageDbContext _context;
+    public AllVehiclesViewModel(HaulageDbContext vehicleContext)
+        {
+            _context = vehicleContext;
+
+            try
+            {
+                var vehicles = _context.vehicle.ToList().Select(n => new VehicleViewModel(_context, n));
+                AllVehicles = new ObservableCollection<VehicleViewModel>(vehicles);
+            }
+            catch (Exception ex)
+            {
+                Shell.Current.DisplayAlert("Error","Error initialising AllVehicles", "Confirm");
+                AllVehicles = new ObservableCollection<VehicleViewModel>(); // Initialize to avoid null reference
+            }
+
+            NewCommand = new AsyncRelayCommand(NewVehicleAsync);
+            SelectVehicleCommand = new AsyncRelayCommand<VehicleViewModel>(SelectVehicleAsync);
+        }
+        private async Task NewVehicleAsync()
+        {
+            await Shell.Current.GoToAsync(nameof(Views.VehiclePage));
+        }
+
+        private async Task SelectVehicleAsync(VehicleViewModel? vehicle)
+        {
+            if (vehicle != null)
+            {
+                await Shell.Current.GoToAsync($"{nameof(Views.VehiclePage)}?load={vehicle.Id}");
+            }
+        }
+
+        void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
+        {
+            if (query.ContainsKey("deleted"))
+            {
+                string vehicleIdStr = query["deleted"].ToString();
+                if (int.TryParse(vehicleIdStr, out int vehicleId))
+                {
+                    var matchedVehicle = AllVehicles.FirstOrDefault(n => n.Id == vehicleId);
+
+                    // If vehicle exists, delete it
+                    if (matchedVehicle != null)
+                    {
+                        AllVehicles.Remove(matchedVehicle);
+                    }
+                    else
+                    {
+                        Shell.Current.DisplayAlert("Warning",$"Vehicle not found in AllVehicles", "Confirm");
+                    }
+                }
+                else
+                {
+                    Shell.Current.DisplayAlert("Error",$"Invalid Vehicle in query for deletion", "Confirm");
+                }
+            }
+            else if (query.ContainsKey("saved"))
+            {
+                string vehicleIdStr = query["saved"].ToString();
+                if (int.TryParse(vehicleIdStr, out int vehicleId))
+                {
+                    var matchedVehicle = AllVehicles.FirstOrDefault(n => n.Id == vehicleId);
+
+                    // If vehicle is found, update it
+                    if (matchedVehicle != null)
+                    {
+                        matchedVehicle.Reload();
+                        AllVehicles.Move(AllVehicles.IndexOf(matchedVehicle), 0);
+                    }
+                    // If vehicle isn't found, it's new; add it.
+                    else
+                    {
+                        var newVehicle = new VehicleViewModel(_context, _context.vehicle.Single(n => n.Id == vehicleId));
+                        AllVehicles.Insert(0, newVehicle);
+                    }
+                }
+                else
+                {
+                    Shell.Current.DisplayAlert("Error",$"Invalid Vehicle in query for saving", "Confirm");
+                }
+            }
+        }
+        
+}

--- a/HaulageApplication/HaulageApp/ViewModels/VehicleViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/VehicleViewModel.cs
@@ -1,0 +1,104 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using HaulageApp.Models;
+using HaulageApp.Data;
+
+namespace HaulageApp.ViewModels;
+
+public partial class VehicleViewModel : ObservableObject, IQueryAttributable
+{
+    private readonly HaulageDbContext _context;
+    private Vehicle _vehicle;
+
+    public VehicleViewModel(HaulageDbContext dbContext)
+    {
+        _context = dbContext;
+        _vehicle = new Vehicle();
+    }
+    
+    public VehicleViewModel(HaulageDbContext dbContext, Vehicle vehicle)
+    {
+        _context = dbContext;
+        _vehicle = vehicle;
+    }
+
+    public string Type
+    {
+        get => _vehicle.Type;
+        set
+        {
+            if (_vehicle.Type != value)
+            {
+                _vehicle.Type = value;
+            }
+        }
+    }
+    
+    public int Capacity
+    {
+        get => _vehicle.Capacity;
+        set
+        {
+            if (_vehicle.Capacity != value)
+            {
+                _vehicle.Capacity = value;
+            }
+        }
+    }
+    
+    public string Status
+    {
+        get => _vehicle.Status;
+        set
+        {
+            if (_vehicle.Status != value)
+            {
+                _vehicle.Status = value;
+            }
+        }
+    }
+
+    public int Id => _vehicle.Id;
+    
+    [RelayCommand]
+    private async Task Save()
+    {
+        if (_vehicle.Id == 0)
+        {
+            _context.vehicle.Add(_vehicle);
+        }
+        _context.SaveChanges();
+        await Shell.Current.GoToAsync($"..?saved={_vehicle.Id}");
+    }
+
+    [RelayCommand]
+    private async Task Delete()
+    {
+        _context.Remove(_vehicle);
+        _context.SaveChanges();
+        await Shell.Current.GoToAsync($"..?deleted={_vehicle.Id}");
+    }
+
+    void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.ContainsKey("load"))
+        { 
+            int vehicleId = int.Parse(query["load"].ToString());
+            _vehicle = _context.vehicle.Single(n => n.Id == vehicleId);
+            RefreshProperties();
+        }
+    }
+    public void Reload()
+    {
+        _context.Entry(_vehicle).Reload();
+        RefreshProperties();
+    }
+
+    private void RefreshProperties()
+    {
+        OnPropertyChanged(nameof(Type));
+        OnPropertyChanged(nameof(Capacity));
+        OnPropertyChanged(nameof(Status));
+    }
+
+}

--- a/HaulageApplication/HaulageApp/Views/AllVehiclesPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/AllVehiclesPage.xaml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HaulageApp.Views.AllVehiclesPage"
+             Title="HaulageApp Vehicles"
+             NavigatedTo="ContentPage_NavigatedTo">
+    <!-- Add an item to the toolbar -->
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Add" Command="{Binding NewCommand}" IconImageSource="{FontImage Glyph='+', Color=Black, Size=22}" />
+    </ContentPage.ToolbarItems>
+
+    <!-- Display vehicles in a list -->
+    <CollectionView x:Name="vehicleCollection"
+                    ItemsSource="{Binding AllVehicles}"
+                    Margin="20"
+                    SelectionMode="Single"
+                    SelectionChangedCommand="{Binding SelectVehicleCommand}"
+                    SelectionChangedCommandParameter="{Binding Source={RelativeSource Self}, Path=SelectedItem}">
+        <!-- Designate how the collection of items are laid out -->
+        <CollectionView.ItemsLayout>
+            <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
+        </CollectionView.ItemsLayout>
+
+        <!-- Define the appearance of each item in the list -->
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <StackLayout>
+                    <Label Text="{Binding Type}" FontSize="22"/>
+                    <Label Text="{Binding Capacity}" FontSize="22"/>
+                    <Label Text="{Binding Status}" FontSize="22"/>
+                </StackLayout>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/AllVehiclesPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/AllVehiclesPage.xaml.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HaulageApp.ViewModels;
+
+namespace HaulageApp.Views;
+
+public partial class AllVehiclesPage : ContentPage
+{
+    public AllVehiclesPage(AllVehiclesViewModel viewModel)
+    {
+        BindingContext = viewModel;
+        InitializeComponent();
+    }
+    private void ContentPage_NavigatedTo(object sender, NavigatedToEventArgs e)
+    {
+        vehicleCollection.SelectedItem = null;
+    }
+}

--- a/HaulageApplication/HaulageApp/Views/VehiclePage.xaml
+++ b/HaulageApplication/HaulageApp/Views/VehiclePage.xaml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HaulageApp.Views.VehiclePage"
+             Title="Vehicle">
+    <VerticalStackLayout Spacing="10" Margin="5">
+        <Editor x:Name="TypeEditor"
+                Placeholder="Enter the Type"
+                Text="{Binding Type}"
+                HeightRequest="100"/>
+        <Editor x:Name="CapacityEditor"
+                Placeholder="Enter the Capacity"
+                Text="{Binding Capacity}"
+                HeightRequest="100"/>
+        <CollectionView x:Name="StatusSelector"
+                        SelectionMode="Single"
+                        SelectedItem="{Binding Status}">
+                        <CollectionView.ItemsSource>
+                            <x:Array Type="{x:Type x:String}">
+                                <x:String>available</x:String> 
+                                <x:String>in use</x:String>
+                            </x:Array>
+                        </CollectionView.ItemsSource>
+        </CollectionView>
+
+        <Grid ColumnDefinitions="*,*" ColumnSpacing="4">
+            <Button Text="Save"
+                    Command="{Binding SaveCommand}"/>
+
+            <Button Grid.Column="1"
+                    Text="Delete"
+                    Command="{Binding DeleteCommand}"/>
+
+        </Grid>
+    </VerticalStackLayout>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/VehiclePage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/VehiclePage.xaml.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HaulageApp.ViewModels;
+
+namespace HaulageApp.Views;
+
+public partial class VehiclePage : ContentPage
+{
+    public VehiclePage(VehicleViewModel viewModel)
+    {
+        BindingContext = viewModel;
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Resolves[#16]
Vehicles can be viewed in a list, when a specific vehicle is clicked on the details can be updated. There is also the functionality to both add new vehicles and delete existing vehicles.

Next Steps:
- Only allow admin to see/manage vehicles
- Add Unit Tests
- Add more robust validity checks

Tested flow using iOS 17 iPhone 15 simulator.
<img width="432" alt="image" src="https://github.com/user-attachments/assets/5315a455-b5b5-44e8-9afb-bc4fa2d146cd">

![image](https://github.com/user-attachments/assets/9a8a35be-64c1-462b-887c-429e90df43b5)
