### PR TITLE
 #11 Introduce TripViewPage to see the trips, edit start & end time

### DIFF
--- a/HaulageApplication/HaulageApp/App.xaml
+++ b/HaulageApplication/HaulageApp/App.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version = "1.0" encoding = "UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:HaulageApp"

--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -49,5 +49,11 @@
                 ContentTemplate="{DataTemplate views:SettingsPage}"
                 Route="settings" />
         </Tab>
+        <Tab Title="Trips" Icon="{OnPlatform 'icon_notes.png', iOS='icon_notes_ios.png', MacCatalyst='icon_notes_ios.png'}">
+            <ShellContent
+                Title="Trip"
+                ContentTemplate="{DataTemplate views:TripPage}"
+                Route="trip"/>
+        </Tab>
     </TabBar>
 </Shell>

--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -12,6 +12,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("login", typeof(LoginPage));
         Routing.RegisterRoute("vehicles", typeof(AllVehiclesPage));
         Routing.RegisterRoute(nameof(NotePage), typeof(NotePage));
+        Routing.RegisterRoute("trip", typeof(TripPage));
         Routing.RegisterRoute("settings", typeof(SettingsPage));
         Routing.RegisterRoute(nameof(VehiclePage), typeof(VehiclePage));
     }

--- a/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
+++ b/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
@@ -12,6 +12,7 @@ namespace HaulageApp.Data
 
         public DbSet<Note> note { get; set; }
         public DbSet<User> user { get; set; }
+        public DbSet<Trip> trip { get; set; }
         public DbSet<Vehicle> vehicle { get; set; }
     }
 }

--- a/HaulageApplication/HaulageApp/HaulageApp.csproj
+++ b/HaulageApplication/HaulageApp/HaulageApp.csproj
@@ -40,20 +40,20 @@
 
     <ItemGroup>
         <!-- App Icon -->
-        <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4"/>
+        <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
 
         <!-- Splash Screen -->
-        <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128"/>
+        <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
 
         <!-- Images -->
-        <MauiImage Include="Resources\Images\*"/>
-        <MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185"/>
+        <MauiImage Include="Resources\Images\*" />
+        <MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />
 
         <!-- Custom Fonts -->
-        <MauiFont Include="Resources\Fonts\*"/>
+        <MauiFont Include="Resources\Fonts\*" />
 
         <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)"/>
+        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
     </ItemGroup>
 
     <ItemGroup>
@@ -62,9 +62,9 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.6.24327.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.6.24327.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0-preview.6.24327.7" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
         <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
         <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.8" />
     </ItemGroup>
@@ -128,7 +128,11 @@
       <Compile Update="Views\AllVehiclesPage.xaml.cs">
         <DependentUpon>AllVehiclesPage.xaml</DependentUpon>
         <SubType>Code</SubType>
-      </Compile>  
+      </Compile>
+      <Compile Update="Views\TripPage.xaml.cs">
+          <DependentUpon>TripPage.xaml</DependentUpon>
+          <SubType>Code</SubType>
+      </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/HaulageApplication/HaulageApp/MauiProgram.cs
+++ b/HaulageApplication/HaulageApp/MauiProgram.cs
@@ -57,7 +57,10 @@ public static class MauiProgram
         builder.Services.AddTransient<VehiclePage>();
         builder.Services.AddSingleton<AllVehiclesViewModel>();
         builder.Services.AddTransient<VehicleViewModel>();
-
+        
+        builder.Services.AddSingleton<TripViewModel>();
+        builder.Services.AddTransient<TripPage>();
+        
 #if DEBUG
         builder.Logging.AddDebug();
 #endif

--- a/HaulageApplication/HaulageApp/Models/Trip.cs
+++ b/HaulageApplication/HaulageApp/Models/Trip.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace HaulageApp.Models
+{
+    [Table("trip")]
+    [PrimaryKey(nameof(Id))]
+    public class Trip
+    {
+        public int Id { get; set; }
+        
+        [ForeignKey(nameof(Vehicle))]
+        public int Vehicle { get; set; }
+        [ForeignKey(nameof(Driver))]
+        public int Driver { get; set; } 
+
+        [Column("start_time")]
+        public DateTime StartTime { get; set; }
+
+        [Column("end_time")]
+        public DateTime? EndTime { get; set; } 
+
+        [Column("status")]
+        public string Status { get; set; } 
+
+        [Column("updated_at")]
+        public DateTime UpdatedAt { get; set; } 
+        public virtual ICollection<Waypoint> Waypoints { get; set; }
+    }
+}

--- a/HaulageApplication/HaulageApp/Models/Waypoint.cs
+++ b/HaulageApplication/HaulageApp/Models/Waypoint.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace HaulageApp.Models
+{
+    [Table("waypoint")]  
+    public class Waypoint
+    {
+        [Key]
+        [Column("waypoint_id")]  
+        public int WaypointId { get; set; }
+
+        [ForeignKey("trip")]
+        [Column("trip_id")] 
+        public int TripId { get; set; }
+
+        [ForeignKey("user")]
+        [Column("user_id")] 
+        public int UserId { get; set; }
+
+        [Column("location")]  
+        public string Location { get; set; }
+
+        [Column("arrival_time")]  
+        public DateTime? ArrivalTime { get; set; }
+
+        [Column("departure_time")]  
+        public DateTime? DepartureTime { get; set; }
+
+        [Column("waypoint_type")]  
+        public string WaypointType { get; set; }
+
+
+        public virtual Trip Trip { get; set; }
+    }
+}

--- a/HaulageApplication/HaulageApp/ViewModels/TripItemViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/TripItemViewModel.cs
@@ -1,0 +1,163 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Windows.Input;
+using HaulageApp.Data;
+using HaulageApp.Models;
+
+namespace HaulageApp.ViewModels
+{
+    public class TripItemViewModel : INotifyPropertyChanged
+    {
+        private readonly HaulageDbContext _context;
+        private Trip _trip;
+        private bool _isEditing;
+
+        private string _tempStartTimeString;
+        private string _tempEndTimeString;
+
+        public TripItemViewModel(Trip trip, HaulageDbContext context)
+        {
+            _trip = trip;
+            _context = context;
+
+            _tempStartTimeString = _trip.StartTime.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+            _tempEndTimeString = _trip.EndTime?.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) ?? string.Empty;
+
+            ToggleEditCommand = new Command(async () =>
+            {
+                if (IsEditing)
+                {
+                    await SaveTrip();
+                }
+
+                IsEditing = !IsEditing;
+
+                OnPropertyChanged(nameof(EditSaveButtonText));
+                OnPropertyChanged(nameof(IsEditing));
+            });
+        }
+
+        public int TripId => _trip.Id;
+
+        public string Status
+        {
+            get => _trip.Status;
+            set
+            {
+                if (_trip.Status != value)
+                {
+                    _trip.Status = value;
+                    OnPropertyChanged(nameof(Status));
+                }
+            }
+        }
+
+        public string StartTimeString
+        {
+            get => _tempStartTimeString;
+            set
+            {
+                if (_tempStartTimeString != value)
+                {
+                    _tempStartTimeString = value;
+                    OnPropertyChanged(nameof(StartTimeString));
+                }
+            }
+        }
+
+        public string EndTimeString
+        {
+            get => _tempEndTimeString;
+            set
+            {
+                if (_tempEndTimeString != value)
+                {
+                    _tempEndTimeString = value;
+                    OnPropertyChanged(nameof(EndTimeString));
+                }
+            }
+        }
+
+        public string EditSaveButtonText => IsEditing ? "Save" : "Edit";
+
+        public bool IsEditing
+        {
+            get => _isEditing;
+            set
+            {
+                if (_isEditing != value)
+                {
+                    _isEditing = value;
+                    OnPropertyChanged(nameof(IsEditing));
+                    OnPropertyChanged(nameof(EditSaveButtonText)); // Notify change here to update button text
+                }
+            }
+        }
+
+        public ObservableCollection<Waypoint> Waypoints => new ObservableCollection<Waypoint>(_trip.Waypoints);
+
+        public ICommand ToggleEditCommand { get; }
+
+        public async Task SaveTrip()
+        {
+            try
+            {
+                if (DateTime.TryParseExact(_tempStartTimeString, "yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedStartTime))
+                {
+                    _trip.StartTime = parsedStartTime;
+                }
+
+                if (DateTime.TryParseExact(_tempEndTimeString, "yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedEndTime))
+                {
+                    _trip.EndTime = parsedEndTime;
+                }
+                else
+                {
+                    _trip.EndTime = null;
+                }
+
+                if (_trip.EndTime.HasValue)
+                {
+                    if (_trip.Status != "completed")
+                    {
+                        Status = "completed";
+                    }
+                }
+                else
+                {
+                    Status = "ongoing";
+                }
+
+                _trip.UpdatedAt = DateTime.Now;
+
+                if (_context.Entry(_trip).State == Microsoft.EntityFrameworkCore.EntityState.Detached)
+                {
+                    _context.Attach(_trip);
+                }
+
+                _context.Update(_trip);
+                await _context.SaveChangesAsync();
+
+                OnPropertyChanged(nameof(Status));
+                OnPropertyChanged(nameof(StartTimeString));
+                OnPropertyChanged(nameof(EndTimeString));
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error saving trip: {ex.Message}");
+                if (ex.InnerException != null)
+                {
+                    Console.WriteLine($"Inner exception: {ex.InnerException.Message}");
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/HaulageApplication/HaulageApp/ViewModels/TripViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/TripViewModel.cs
@@ -1,0 +1,58 @@
+using HaulageApp.Data;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Microsoft.EntityFrameworkCore;
+
+namespace HaulageApp.ViewModels
+{
+    public class TripViewModel : INotifyPropertyChanged
+    {
+        private readonly HaulageDbContext _context;
+        private ObservableCollection<TripItemViewModel> _tripGroups;
+
+        public ObservableCollection<TripItemViewModel> TripGroups
+        {
+            get => _tripGroups;
+            set
+            {
+                _tripGroups = value;
+                OnPropertyChanged(nameof(TripGroups));
+            }
+        }
+
+        public TripViewModel(HaulageDbContext context)
+        {
+            _context = context;
+            LoadData();
+        }
+
+        private async void LoadData()
+        {
+            try
+            {
+                var trips = await _context.trip
+                    .Include(t => t.Waypoints)
+                    .ToListAsync();
+
+                TripGroups = new ObservableCollection<TripItemViewModel>(
+                    trips.Select(trip => new TripItemViewModel(trip, _context))
+                );
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error loading data: {ex.Message}");
+                if (ex.InnerException != null)
+                {
+                    Console.WriteLine($"Inner exception: {ex.InnerException.Message}");
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/HaulageApplication/HaulageApp/Views/TripPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/TripPage.xaml
@@ -1,0 +1,47 @@
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HaulageApp.Views.TripPage"
+             Title="Manage Trips">
+
+    <ScrollView>
+        <StackLayout Padding="10">
+            <Label Text="All Trips" FontAttributes="Bold" FontSize="Medium" Margin="10,20,0,0" />
+
+            <CollectionView ItemsSource="{Binding TripGroups}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <StackLayout Padding="10" BackgroundColor="#f0f0f0" Margin="0,0,0,10">
+                            <Label Text="{Binding TripId, StringFormat='Trip Number: {0}'}" FontAttributes="Bold" FontSize="Medium" VerticalTextAlignment="Center" />
+                            <Label Text="{Binding Status, StringFormat='Trip Status: {0}'}" FontSize="Medium" VerticalTextAlignment="Center" />
+
+                            <StackLayout>
+                                <Label Text="Start Time:" FontAttributes="Bold" />
+                                <Entry Text="{Binding StartTimeString, Mode=TwoWay}" IsEnabled="{Binding IsEditing}" Placeholder="YYYY-MM-DD HH:MM" />
+                            </StackLayout>
+
+                            <StackLayout>
+                                <Label Text="End Time:" FontAttributes="Bold" />
+                                <Entry Text="{Binding EndTimeString, Mode=TwoWay}" IsEnabled="{Binding IsEditing}" Placeholder="YYYY-MM-DD HH:MM" />
+                            </StackLayout>
+
+                            <Label Text="Stops:" FontAttributes="Bold" FontSize="Medium" Margin="10,10,0,0"/>
+                            <CollectionView ItemsSource="{Binding Waypoints}">
+                                <CollectionView.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackLayout Padding="5">
+                                            <Label Text="{Binding WaypointType}" FontAttributes="Bold" FontSize="Small" VerticalTextAlignment="Center" />
+                                            <Label Text="{Binding Location}" FontSize="Small" VerticalTextAlignment="Center" />
+                                        </StackLayout>
+                                    </DataTemplate>
+                                </CollectionView.ItemTemplate>
+                            </CollectionView>
+
+                            <!-- Edit/Save Button -->
+                            <Button Text="{Binding EditSaveButtonText}" Command="{Binding ToggleEditCommand}" />
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </StackLayout>
+    </ScrollView>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/TripPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/TripPage.xaml.cs
@@ -1,0 +1,14 @@
+using HaulageApp.ViewModels;
+using Microsoft.Maui.Controls;
+
+namespace HaulageApp.Views
+{
+    public partial class TripPage : ContentPage
+    {
+        public TripPage(TripViewModel viewModel)
+        {
+            InitializeComponent();
+            BindingContext = viewModel;
+        }
+    }
+}

--- a/HaulageApplication/HaulageAppTests/HaulageAppTests.csproj
+++ b/HaulageApplication/HaulageAppTests/HaulageAppTests.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.7.24405.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="xunit" Version="2.5.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
     </ItemGroup>

--- a/HaulageApplication/HaulageAppTests/TripItemViewModelTests.cs
+++ b/HaulageApplication/HaulageAppTests/TripItemViewModelTests.cs
@@ -1,0 +1,109 @@
+using Moq;
+using HaulageApp.ViewModels;
+using HaulageApp.Data;
+using HaulageApp.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace HaulageApp.Tests
+{
+    public class TripItemViewModelTests
+    {
+        [Fact]
+        public async Task SaveTrip_ShouldUpdateDatabase_WhenCalled()
+        {
+            var mockContext = new Mock<HaulageDbContext>(new DbContextOptions<HaulageDbContext>());
+            var trip = new Trip
+            {
+                Id = 1,
+                StartTime = DateTime.Parse("2024-08-19 08:00"),
+                EndTime = null,
+                Status = "ongoing",
+                UpdatedAt = DateTime.Now
+            };
+            var viewModel = new TripItemViewModel(trip, mockContext.Object)
+            {
+                StartTimeString = "2024-08-19 09:00",
+                EndTimeString = "2024-08-19 12:00"
+            };
+
+            await viewModel.SaveTrip();
+
+            Assert.Equal("completed", viewModel.Status); // Status should be updated to completed
+        }
+
+
+        [Fact]
+        public async Task SaveTrip_ShouldChangeStatus_WhenEndTimeIsNotrefinedButUpdatedAtWasChanged()
+        {
+            var mockContext = new Mock<HaulageDbContext>(new DbContextOptions<HaulageDbContext>());
+            var trip = new Trip
+            {
+                Id = 1,
+                StartTime = DateTime.Parse("2024-08-19 08:00"),
+                EndTime = null, // No end time
+                Status = "planned",
+                UpdatedAt = DateTime.Now
+            };
+            
+            var viewModel = new TripItemViewModel(trip, mockContext.Object)
+            {
+                StartTimeString = trip.StartTime.ToString("yyyy-MM-dd HH:mm"),
+                EndTimeString = "" // No changes made to EndTime
+            };
+            await viewModel.SaveTrip();
+            
+            Assert.Equal("ongoing", viewModel.Status); // Status should remain as "planned"
+        }
+
+        [Fact]
+        public async Task SaveTrip_ShouldNotUpdateDatabase_WhenNoChangesMade()
+        {
+            var mockContext = new Mock<HaulageDbContext>(new DbContextOptions<HaulageDbContext>());
+            var trip = new Trip
+            {
+                Id = 1,
+                StartTime = DateTime.Parse("2024-08-19 08:00"),
+                EndTime = DateTime.Parse("2024-08-19 12:00"),
+                Status = "completed",
+                UpdatedAt = DateTime.Now
+            };
+
+            mockContext.Setup(c => c.Attach(It.IsAny<Trip>())).Verifiable();
+            mockContext.Setup(c => c.Update(It.IsAny<Trip>())).Verifiable();
+            mockContext.Setup(c => c.SaveChangesAsync(default)).ReturnsAsync(1);
+
+            var viewModel = new TripItemViewModel(trip, mockContext.Object)
+            {
+                StartTimeString = "2024-08-19 08:00",
+                EndTimeString = "2024-08-19 12:00"
+            };
+            await viewModel.SaveTrip();
+
+            mockContext.Verify(c => c.Attach(It.IsAny<Trip>()), Times.Never);
+            mockContext.Verify(c => c.Update(It.IsAny<Trip>()), Times.Never);
+            mockContext.Verify(c => c.SaveChangesAsync(default), Times.Never);
+        }
+        
+        [Fact]
+        public void ToggleEditCommand_ShouldToggleIsEditing_WhenExecuted()
+        {
+            var mockContext = new Mock<HaulageDbContext>(new DbContextOptions<HaulageDbContext>());
+            var trip = new Trip
+            {
+                Id = 1,
+                StartTime = DateTime.Parse("2024-08-19 08:00"),
+                EndTime = DateTime.Parse("2024-08-19 12:00"),
+                Status = "completed",
+                UpdatedAt = DateTime.Now
+            };
+
+            var viewModel = new TripItemViewModel(trip, mockContext.Object);
+
+            Assert.False(viewModel.IsEditing); // Initially not editing
+            viewModel.ToggleEditCommand.Execute(null);
+            Assert.True(viewModel.IsEditing); // Should be editing after first toggle
+            viewModel.ToggleEditCommand.Execute(null);
+            Assert.False(viewModel.IsEditing); // Should not be editing after second toggle
+        }
+    }
+}


### PR DESCRIPTION
Introduce TripViewPage to see the trips, edit start & end time, see stops for the trip + Add Unit Tests for TripItemViewModel


Testing: 
- Pulled all the recent changed from `dev` branch and build 
- Tested locally
- Added unit tests (there is a failing test not related to the change) 
![Trip1Details](https://github.com/user-attachments/assets/74847148-5503-43ad-8676-06b5db238ac1)


The whole flow of the app can be seen here: 

- Updating time of the completed trip 
- Updating time of the ongoing trip and marking it complete 

![Trip1Details](https://github.com/user-attachments/assets/74847148-5503-43ad-8676-06b5db238ac1)
![Trip12Details](https://github.com/user-attachments/assets/1c5747f5-d226-47bb-9100-dfb6c62f280e)
![Trip12UpdatedDetails](https://github.com/user-attachments/assets/ebb20616-fadb-41cc-b027-919c138ee3cf)
![Trip1UpdatedDetails](https://github.com/user-attachments/assets/c5291131-fb01-479e-aa32-3b5edd6f59ae)