### PR TITLE
[#17] Add permissions view model and blank ManageCustomers page

### DIFF
--- a/HaulageApplication/HaulageApp/App.xaml.cs
+++ b/HaulageApplication/HaulageApp/App.xaml.cs
@@ -2,11 +2,10 @@
 
 public partial class App : Application
 {
-    public App()
+    public App(AppShell shell)
     {
         InitializeComponent();
-
         
-        MainPage = new AppShell();
+        MainPage = shell;
     }
 }

--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -18,12 +18,13 @@
         Route="login" />
 
     <TabBar>
-        <Tab Title="Home"
+        <Tab Title="Notes"
              Icon="{OnPlatform 'icon_notes.png', iOS='icon_notes_ios.png', MacCatalyst='icon_notes_ios.png'}">
             <ShellContent
                 Title="Home"
                 ContentTemplate="{DataTemplate views:AllNotesPage}"
-                Route="home" />
+                IsVisible="{Binding NotesIsVisible}"
+                Route="notes" />
         </Tab>
 
         <Tab Title="About"
@@ -46,6 +47,14 @@
                 Title="Trip"
                 ContentTemplate="{DataTemplate views:TripPage}"
                 Route="trip"/>
+        </Tab>
+        
+        <Tab Title="Manage Customers" Icon="{OnPlatform 'icon_notes.png', iOS='icon_notes_ios.png', MacCatalyst='icon_notes_ios.png'}">
+            <ShellContent
+                Title="Manage Customers"
+                ContentTemplate="{DataTemplate views:ManageCustomersPage}"
+                IsVisible="{Binding ManageCustomersIsVisible}"
+                Route="manageCustomers"/>
         </Tab>
         
         <Tab Title="Settings" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">

--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -1,14 +1,16 @@
-﻿using HaulageApp.Views;
+﻿using HaulageApp.ViewModels;
+using HaulageApp.Views;
 
 namespace HaulageApp;
 
 public partial class AppShell : Shell
 {
-    public AppShell()
+    public AppShell(PermissionsViewModel viewmodel)
     {
+        BindingContext = viewmodel;
         InitializeComponent();
 
-        Routing.RegisterRoute("home", typeof(AllNotesPage));
+        Routing.RegisterRoute("notes", typeof(AllNotesPage));
         Routing.RegisterRoute("login", typeof(LoginPage));
         Routing.RegisterRoute("vehicles", typeof(AllVehiclesPage));
         Routing.RegisterRoute(nameof(NotePage), typeof(NotePage));
@@ -16,5 +18,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("settings", typeof(SettingsPage));
         Routing.RegisterRoute(nameof(VehiclePage), typeof(VehiclePage));
         Routing.RegisterRoute(nameof(EditExpensePage), typeof(EditExpensePage));
+        
+        viewmodel.UpdateTabsForCurrentUser();
     }
 }

--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -19,6 +19,5 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(VehiclePage), typeof(VehiclePage));
         Routing.RegisterRoute(nameof(EditExpensePage), typeof(EditExpensePage));
         
-        viewmodel.UpdateTabsForCurrentUser();
     }
 }

--- a/HaulageApplication/HaulageApp/HaulageApp.csproj
+++ b/HaulageApplication/HaulageApp/HaulageApp.csproj
@@ -103,6 +103,9 @@
       <MauiXaml Update="Views\EditExpensePage.xaml">
         <SubType>Designer</SubType>
       </MauiXaml>
+      <MauiXaml Update="Views\ManageCustomersPage.xaml">
+        <SubType>Designer</SubType>
+      </MauiXaml>
     </ItemGroup>
 
     <ItemGroup>
@@ -153,6 +156,10 @@
       <Compile Update="Views\TripPage.xaml.cs">
           <DependentUpon>TripPage.xaml</DependentUpon>
           <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Views\ManageCustomersPage.xaml.cs">
+        <DependentUpon>ManageCustomers.xaml</DependentUpon>
+        <SubType>Code</SubType>
       </Compile>
     </ItemGroup>
 

--- a/HaulageApplication/HaulageApp/MauiProgram.cs
+++ b/HaulageApplication/HaulageApp/MauiProgram.cs
@@ -48,13 +48,16 @@ public static class MauiProgram
         builder.Services.AddSingleton<TripViewModel>();
         builder.Services.AddTransient<TripPage>();
         
+        builder.Services.AddTransient<ManageCustomersViewModel>();
+        builder.Services.AddTransient<ManageCustomersPage>();
+        
         builder.Services.AddTransient<ExpensesViewModel>();
         builder.Services.AddTransient<ExpensesPage>();
         
         builder.Services.AddTransient<EditExpenseViewModel>();
         builder.Services.AddTransient<EditExpensePage>();
         
-        builder.Services.AddSingleton<SettingsViewModel>();
+        builder.Services.AddTransient<SettingsViewModel>();
         builder.Services.AddTransient<SettingsPage>();
         
         builder.Services.AddSingleton<LoginViewModel>();
@@ -70,6 +73,9 @@ public static class MauiProgram
         
         builder.Services.AddSingleton<TripViewModel>();
         builder.Services.AddTransient<TripPage>();
+
+        builder.Services.AddTransient<AppShell>();
+        builder.Services.AddSingleton<PermissionsViewModel>();
         
 #if DEBUG
         builder.Logging.AddDebug();

--- a/HaulageApplication/HaulageApp/ViewModels/ManageCustomersViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/ManageCustomersViewModel.cs
@@ -1,0 +1,6 @@
+namespace HaulageApp.ViewModels;
+
+public class ManageCustomersViewModel
+{
+    
+}

--- a/HaulageApplication/HaulageApp/ViewModels/PermissionsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/PermissionsViewModel.cs
@@ -1,18 +1,29 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using HaulageApp.Common;
 using HaulageApp.Data;
 using HaulageApp.Models;
 
 namespace HaulageApp.ViewModels;
 
-public partial class PermissionsViewModel(HaulageDbContext dbContext) : ObservableObject
+public partial class PermissionsViewModel : ObservableObject
 {
     [ObservableProperty] private bool _manageCustomersIsVisible;
     // example (using notes)
     [ObservableProperty] private bool _notesIsVisible;
+    
+    private readonly HaulageDbContext _dbContext;
+    private readonly IPreferencesWrapper _preferencesWrapper;
+
+    public PermissionsViewModel(HaulageDbContext dbContext, IPreferencesWrapper preferencesWrapper)
+    {
+        _dbContext = dbContext;
+        _preferencesWrapper = preferencesWrapper;
+        UpdateTabsForCurrentUser();
+    }
 
     public void UpdateTabsForCurrentUser()
     {
-        var username = Preferences.Get("hasAuth", "");
+        var username = _preferencesWrapper.Get<string>("hasAuth", "");
         var user = GetUser(username);
         if (user != null)
         {
@@ -27,7 +38,7 @@ public partial class PermissionsViewModel(HaulageDbContext dbContext) : Observab
 
     private User? GetUser(string username)
     {
-        return dbContext.user
+        return _dbContext.user
             .AsQueryable()
             .FirstOrDefault(u => u.Email == username.ToLower());
     }

--- a/HaulageApplication/HaulageApp/ViewModels/PermissionsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/PermissionsViewModel.cs
@@ -1,0 +1,59 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using HaulageApp.Data;
+using HaulageApp.Models;
+
+namespace HaulageApp.ViewModels;
+
+public partial class PermissionsViewModel(HaulageDbContext dbContext) : ObservableObject
+{
+    [ObservableProperty] private bool _manageCustomersIsVisible;
+    // example (using notes)
+    [ObservableProperty] private bool _notesIsVisible;
+
+    public void UpdateTabsForCurrentUser()
+    {
+        var username = Preferences.Get("hasAuth", "");
+        var user = GetUser(username);
+        if (user != null)
+        {
+            SetVisibilityByRole(user.Role);
+        }
+    }
+    
+    public void UpdateTabsForCurrentUser(int roleId)
+    {
+        SetVisibilityByRole(roleId);
+    }
+
+    private User? GetUser(string username)
+    {
+        return dbContext.user
+            .AsQueryable()
+            .FirstOrDefault(u => u.Email == username.ToLower());
+    }
+    
+    private void SetVisibilityByRole(int roleId)
+    {
+        // It would be better to check the role name rather than ID.
+        // This just requires an additional call to the db to check 
+        // the role name against id. For simplicity just adding this for now.
+        switch (roleId)
+        {
+            default:
+                // Customer (and anyone else)
+                NotesIsVisible = false;
+                ManageCustomersIsVisible = false;
+                break; 
+            case 2:
+                // Driver
+                NotesIsVisible = true;
+                ManageCustomersIsVisible = false;
+                break;
+            case 3:
+                // Admin
+                NotesIsVisible = false;
+                ManageCustomersIsVisible = true;
+                break;
+        }
+    }
+}

--- a/HaulageApplication/HaulageApp/Views/LoadingPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/LoadingPage.xaml.cs
@@ -11,7 +11,11 @@ public partial class LoadingPage : ContentPage
     {
         if (IsAuthenticated())
         {
-            await Shell.Current.GoToAsync("///home");
+            // Should be a page that all roles have access to, e.g. settings.
+            // Another option is to add the role to user defaults and can go 
+            // to a different page based on which role is logged in. (e.g. switch
+            // case based on role)
+            await Shell.Current.GoToAsync("///settings");
         }
         else
         {
@@ -22,7 +26,6 @@ public partial class LoadingPage : ContentPage
 
     private bool IsAuthenticated()
     {
-        var hasAuth = Preferences.Default.ContainsKey("hasAuth");
-        return hasAuth;
+        return Preferences.Default.ContainsKey("hasAuth");
     }
 }

--- a/HaulageApplication/HaulageApp/Views/ManageCustomersPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/ManageCustomersPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HaulageApp.Views.ManageCustomersPage">
+    <ContentPage.Content>
+        
+    </ContentPage.Content>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/ManageCustomersPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/ManageCustomersPage.xaml.cs
@@ -1,0 +1,12 @@
+using HaulageApp.ViewModels;
+
+namespace HaulageApp.Views;
+
+public partial class ManageCustomersPage : ContentPage
+{
+    public ManageCustomersPage(ManageCustomersViewModel viewModel)
+    {
+        BindingContext = viewModel;
+        InitializeComponent();
+    }
+}

--- a/HaulageApplication/HaulageAppTests/CredentialsTest.cs
+++ b/HaulageApplication/HaulageAppTests/CredentialsTest.cs
@@ -1,37 +1,41 @@
 using HaulageApp.Data;
+using HaulageApp.Models;
 using HaulageApp.ViewModels;
 
 namespace HaulageAppTests;
 
 public class CredentialsTest
 {
-    private MockDb db = new();
+    private readonly MockDb _db = new();
     
     [Fact]
     public void CredentialsReturnsTrueWhenDataExists()
     {
-        var options = db.CreateContextOptions();
-        
-        db.CreateContext(options);
+        var options = _db.CreateContextOptions();
+        _db.CreateContext(options);
         
         using (var context = new HaulageDbContext(options))
         {
-            var viewmodel = new LoginViewModel(context);
-            Assert.True(viewmodel.IsCredentialCorrect("customer", "1234"));
+            var permissionsViewModel = new PermissionsViewModel(context);
+            var viewmodel = new LoginViewModel(context, permissionsViewModel);
+            User? user = context.user.FirstOrDefault();
+            Assert.True(viewmodel.IsCredentialCorrect(user!, "1234"));
         }
     }
     
     [Fact]
     public void CredentialsReturnsFalseWhenDataDoesNotExist()
     {
-        var options = db.CreateContextOptions();
+        var options = _db.CreateContextOptions();
         
-        db.CreateContext(options);
+        _db.CreateContext(options);
         
         using (var context = new HaulageDbContext(options))
         {
-            var viewmodel = new LoginViewModel(context);
-            Assert.False(viewmodel.IsCredentialCorrect("who", "1234"));
+            var permissionsViewModel = new PermissionsViewModel(context);
+            var viewmodel = new LoginViewModel(context, permissionsViewModel);
+            User? user = context.user.FirstOrDefault();
+            Assert.False(viewmodel.IsCredentialCorrect(user!, "3456"));
         }
     }
 }

--- a/HaulageApplication/HaulageAppTests/CredentialsTest.cs
+++ b/HaulageApplication/HaulageAppTests/CredentialsTest.cs
@@ -1,3 +1,4 @@
+using HaulageApp.Common;
 using HaulageApp.Data;
 using HaulageApp.Models;
 using HaulageApp.ViewModels;
@@ -7,6 +8,7 @@ namespace HaulageAppTests;
 public class CredentialsTest
 {
     private readonly MockDb _db = new();
+    private FakePreferencesWrapper fakeStorage = new();
     
     [Fact]
     public void CredentialsReturnsTrueWhenDataExists()
@@ -16,7 +18,7 @@ public class CredentialsTest
         
         using (var context = new HaulageDbContext(options))
         {
-            var permissionsViewModel = new PermissionsViewModel(context);
+            var permissionsViewModel = new PermissionsViewModel(context, fakeStorage);
             var viewmodel = new LoginViewModel(context, permissionsViewModel);
             User? user = context.user.FirstOrDefault();
             Assert.True(viewmodel.IsCredentialCorrect(user!, "1234"));
@@ -32,7 +34,7 @@ public class CredentialsTest
         
         using (var context = new HaulageDbContext(options))
         {
-            var permissionsViewModel = new PermissionsViewModel(context);
+            var permissionsViewModel = new PermissionsViewModel(context, fakeStorage);
             var viewmodel = new LoginViewModel(context, permissionsViewModel);
             User? user = context.user.FirstOrDefault();
             Assert.False(viewmodel.IsCredentialCorrect(user!, "3456"));

--- a/HaulageApplication/HaulageAppTests/PermissionsModelTests.cs
+++ b/HaulageApplication/HaulageAppTests/PermissionsModelTests.cs
@@ -1,0 +1,61 @@
+using HaulageApp.Data;
+using HaulageApp.ViewModels;
+
+namespace HaulageAppTests;
+
+public class PermissionsModelTests
+{
+    private readonly MockDb _db = new();
+    private FakePreferencesWrapper fakeStorage = new();
+    
+    [Fact]
+    public void AssertPageVisibilityWhenUserIsCustomer()
+    {
+        var options = _db.CreateContextOptions();
+        _db.CreateContext(options);
+
+        using (var context = new HaulageDbContext(options))
+        {
+            PermissionsViewModel permissionsViewModel = new PermissionsViewModel(context, fakeStorage);
+
+            fakeStorage.Set<string>("hasAuth", "customer");
+            permissionsViewModel.UpdateTabsForCurrentUser();
+            Assert.False(permissionsViewModel.ManageCustomersIsVisible);
+            Assert.False(permissionsViewModel.NotesIsVisible);
+        }
+    }
+    
+    [Fact]
+    public void AssertPageVisibilityWhenUserIsDriver()
+    {
+        var options = _db.CreateContextOptions();
+        _db.CreateContext(options);
+
+        using (var context = new HaulageDbContext(options))
+        {
+            PermissionsViewModel permissionsViewModel = new PermissionsViewModel(context, fakeStorage);
+
+            fakeStorage.Set<string>("hasAuth", "driver");
+            permissionsViewModel.UpdateTabsForCurrentUser();
+            Assert.False(permissionsViewModel.ManageCustomersIsVisible);
+            Assert.True(permissionsViewModel.NotesIsVisible);
+        }
+    }
+    
+    [Fact]
+    public void AssertPageVisibilityWhenUserIsAdmin()
+    {
+        var options = _db.CreateContextOptions();
+        _db.CreateContext(options);
+
+        using (var context = new HaulageDbContext(options))
+        {
+            PermissionsViewModel permissionsViewModel = new PermissionsViewModel(context, fakeStorage);
+
+            fakeStorage.Set<string>("hasAuth", "admin");
+            permissionsViewModel.UpdateTabsForCurrentUser();
+            Assert.True(permissionsViewModel.ManageCustomersIsVisible);
+            Assert.False(permissionsViewModel.NotesIsVisible);
+        }
+    }
+}


### PR DESCRIPTION
To be able to manage customers as an admin [ #17 ], the "manage customers" page should be restricted to those logged in with the admin role.

This PR introduces a PermissionsViewModel where we can set the visibility of pages based on roles.

The "home" page is now set to a page which all roles have access to. 

I have left comments in the code noting that we could also have a switch statement, for example, where we set the home page to vary depending on what role is logged in if we prefer that. If preferred, you can update as required.

I created a blank page for manage customers for this PR and also showed the example using the notes pages which has different role visibility. See screenshots below. Those working on trips / vehicle tasks can update for their pages as required.

Logged in as admin [wip manage customers]:
![Screenshot 2024-08-23 at 13 21 50](https://github.com/user-attachments/assets/7817a7dc-92f0-4a85-9a7a-3510df3b2e74)

Logged in as a customer:
![Screenshot 2024-08-23 at 13 22 14](https://github.com/user-attachments/assets/d6aaa209-989b-403e-b47f-53bb72f338a0)

Logged in as driver:
![Screenshot 2024-08-23 at 13 28 40](https://github.com/user-attachments/assets/6f33c7a2-07d5-4ce5-96c1-a3e988816f63)

