### PR TITLE
Adding More Robust Validity Checks And Tests

### DIFF
--- a/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
+++ b/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
@@ -13,7 +13,7 @@ namespace HaulageApp.Data
         public DbSet<Note> note { get; set; }
         public DbSet<User> user { get; set; }
         public DbSet<Trip> trip { get; set; }
-        public DbSet<Vehicle> vehicle { get; set; }
+        public virtual DbSet<Vehicle> vehicle { get; set; }
         public virtual DbSet<Expense> expense { get; set; }
     }
 }

--- a/HaulageApplication/HaulageApp/Models/Vehicle.cs
+++ b/HaulageApplication/HaulageApp/Models/Vehicle.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -8,8 +9,14 @@ namespace HaulageApp.Models;
 public class Vehicle
 {
     public int Id { get; set; }
+    
+    [Required]
     public string Type { get; set; }
+    
+    [Range(0, int.MaxValue)]
     public int Capacity { get; set; }
+    
+    [Required]
     public string Status { get; set; }
     
 }

--- a/HaulageApplication/HaulageApp/ViewModels/VehicleViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/VehicleViewModel.cs
@@ -26,8 +26,8 @@ public partial class VehicleViewModel : ObservableObject, IQueryAttributable, IN
         _vehicle = vehicle;
     }
 
-    public bool HasErrors => _errors.Any();
-    public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
+    public bool HasErrors => _errors.Count != 0;
+    public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
 
     public IEnumerable GetErrors(string property)
     {
@@ -101,7 +101,7 @@ public partial class VehicleViewModel : ObservableObject, IQueryAttributable, IN
     [RelayCommand]
     private async Task Delete()
     {
-        _context.Remove(_vehicle);
+        _context.vehicle.Remove(_vehicle);
         _context.SaveChanges();
         await Shell.Current.GoToAsync($"..?deleted={_vehicle.Id}");
     }

--- a/HaulageApplication/HaulageApp/Views/VehiclePage.xaml
+++ b/HaulageApplication/HaulageApp/Views/VehiclePage.xaml
@@ -15,6 +15,7 @@
                 Text="{Binding Capacity}"/>
         <CollectionView x:Name="StatusSelector"
                         SelectionMode="Single"
+                        HeightRequest="50"
                         SelectedItem="{Binding Status}">
                         <CollectionView.ItemsSource>
                             <x:Array Type="{x:Type x:String}">

--- a/HaulageApplication/HaulageApp/Views/VehiclePage.xaml
+++ b/HaulageApplication/HaulageApp/Views/VehiclePage.xaml
@@ -7,12 +7,12 @@
     <VerticalStackLayout Spacing="10" Margin="5">
         <Editor x:Name="TypeEditor"
                 Placeholder="Enter the Type"
-                Text="{Binding Type}"
-                HeightRequest="100"/>
+                HeightRequest="50"
+                Text="{Binding Type}"/>
         <Editor x:Name="CapacityEditor"
                 Placeholder="Enter the Capacity"
-                Text="{Binding Capacity}"
-                HeightRequest="100"/>
+                HeightRequest="50"
+                Text="{Binding Capacity}"/>
         <CollectionView x:Name="StatusSelector"
                         SelectionMode="Single"
                         SelectedItem="{Binding Status}">
@@ -23,7 +23,6 @@
                             </x:Array>
                         </CollectionView.ItemsSource>
         </CollectionView>
-
         <Grid ColumnDefinitions="*,*" ColumnSpacing="4">
             <Button Text="Save"
                     Command="{Binding SaveCommand}"/>

--- a/HaulageApplication/HaulageAppTests/VehicleTests.cs
+++ b/HaulageApplication/HaulageAppTests/VehicleTests.cs
@@ -12,25 +12,34 @@ public class VehicleTests
 {
     private readonly Mock<HaulageDbContext> _mockContext;
     private readonly Mock<DbSet<Vehicle>> _mockVehicle;
+    private readonly Vehicle _vehicle;
     
     public VehicleTests()
     {
         _mockContext = new Mock<HaulageDbContext>();
         _mockVehicle = new Mock<DbSet<Vehicle>>();
+        
+        _vehicle = new Vehicle
+        {
+            Id = 1,
+            Type = "Van",
+            Capacity = 500,
+            Status = "available"
+        };
         _mockContext.Setup(c => c.vehicle).Returns(_mockVehicle.Object);
     }
 
     [Fact]
     public Task SaveShouldAddVehicleToDbWhenNew()
     {
-        var vehicle = new Vehicle
+        var newVehicle = new Vehicle
         {
             Id = 0,
             Type = "Van",
             Capacity = 500,
             Status = "available"
         };
-        var viewModel = new VehicleViewModel(_mockContext.Object, vehicle);
+        var viewModel = new VehicleViewModel(_mockContext.Object, newVehicle);
         viewModel.SaveCommand.Execute(null);
         _mockVehicle.Verify(c => c.Add(It.IsAny<Vehicle>()), Times.Once);
         _mockContext.Verify(c => c.SaveChanges(), Times.Once);
@@ -40,14 +49,7 @@ public class VehicleTests
     [Fact]
     public Task SaveShouldUpdateVehicleToDbWhenExists()
     {
-        var vehicle = new Vehicle
-        {
-            Id = 1,
-            Type = "Van",
-            Capacity = 500,
-            Status = "available"
-        };
-        var viewModel = new VehicleViewModel(_mockContext.Object, vehicle)
+        var viewModel = new VehicleViewModel(_mockContext.Object, _vehicle)
         {
             Type="Van",
             Capacity = 50,
@@ -63,14 +65,7 @@ public class VehicleTests
     [Fact]
     public Task DeleteShouldRemoveVehicle()
     {
-        var vehicle = new Vehicle
-        {
-            Id = 1,
-            Type = "Van",
-            Capacity = 500,
-            Status = "available"
-        };
-        var viewModel = new VehicleViewModel(_mockContext.Object, vehicle);
+        var viewModel = new VehicleViewModel(_mockContext.Object, _vehicle);
         viewModel.DeleteCommand.Execute(null);
         
         _mockVehicle.Verify(c => c.Remove(It.IsAny<Vehicle>()), Times.Once);
@@ -81,15 +76,8 @@ public class VehicleTests
     [Fact]
     public void ReloadShouldReloadContext()
     {
-        var vehicle = new Vehicle
-        {
-            Id = 1,
-            Type = "Van",
-            Capacity = 500,
-            Status = "available"
-        };
-        var viewModel = new VehicleViewModel(_mockContext.Object, vehicle);
-        _mockContext.Setup(c => c.Entry(vehicle)).Returns(new Mock<FakeEntityEntry<Vehicle>>().Object);
+        var viewModel = new VehicleViewModel(_mockContext.Object, _vehicle);
+        _mockContext.Setup(c => c.Entry(_vehicle)).Returns(new Mock<FakeEntityEntry<Vehicle>>().Object);
         viewModel.Reload();
         
         _mockContext.Verify(c => c.Entry(It.IsAny<Vehicle>()).Reload(), Times.Once);

--- a/HaulageApplication/HaulageAppTests/VehicleTests.cs
+++ b/HaulageApplication/HaulageAppTests/VehicleTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.ObjectModel;
+using HaulageApp.Data;
+using HaulageApp.Models;
+using HaulageApp.ViewModels;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace HaulageAppTests;
+
+public class VehicleTests
+{
+    private readonly Mock<HaulageDbContext> _mockContext;
+    private readonly Mock<DbSet<Vehicle>> _mockVehicle;
+    
+    public VehicleTests()
+    {
+        _mockContext = new Mock<HaulageDbContext>();
+        _mockVehicle = new Mock<DbSet<Vehicle>>();
+    }
+
+    [Fact]
+    public async Task SaveShouldAddVehicleToDbWhenNew()
+    {
+        var vehicle = new Vehicle
+        {
+            Id = 1,
+            Type = "Van",
+            Capacity = 500,
+            Status = "available"
+        };
+        _mockContext.Setup(c => c.vehicle).Returns(_mockVehicle.Object);
+        var viewModel = new VehicleViewModel(_mockContext.Object, vehicle);
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+        _mockVehicle.Verify(c => c.Add(It.IsAny<Vehicle>()), Times.Once);
+        _mockContext.Verify(c => c.SaveChanges(), Times.Once);
+        
+    }
+
+    [Fact]
+    public async Task SaveShouldUpdateVehicleToDbWhenExists()
+    {
+        var vehicle = new Vehicle
+        {
+            Id = 1,
+            Type = "Truck",
+            Capacity = 500,
+            Status = "available"
+        };
+        _mockContext.Setup(c => c.vehicle).Returns(_mockVehicle.Object);
+        var viewModel = new VehicleViewModel(_mockContext.Object, vehicle)
+        {
+            Type="Van",
+            Capacity = 50,
+            Status="in use"
+        };
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+        _mockVehicle.Verify(c => c.Add(It.IsAny<Vehicle>()), Times.Never);
+        _mockContext.Verify(c => c.SaveChanges(), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteShouldRemoveVehicle()
+    {
+        var vehicle = new Vehicle
+        {
+            Id = 1,
+            Type = "Truck",
+            Capacity = 500,
+            Status = "available"
+        };
+        _mockContext.Setup(c => c.vehicle).Returns(_mockVehicle.Object);
+        var viewModel = new VehicleViewModel(_mockContext.Object, vehicle);
+        
+        await viewModel.SaveCommand.ExecuteAsync(null);
+        _mockVehicle.Verify(c => c.Remove(It.IsAny<Vehicle>()), Times.Once);
+        _mockContext.Verify(c => c.SaveChanges(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReloadShouldReloadContext()
+    {
+        var vehicle = new Vehicle
+        {
+            Id = 1,
+            Type = "Truck",
+            Capacity = 500,
+            Status = "available"
+        };
+        _mockContext.Setup(c => c.vehicle).Returns(_mockVehicle.Object);
+        var viewModel = new VehicleViewModel(_mockContext.Object, vehicle);
+        
+        viewModel.Reload();
+        
+        _mockContext.Verify(c => c.Entry(It.IsAny<Vehicle>()).Reload(), Times.Once);
+        
+    }
+
+}


### PR DESCRIPTION
Resolves[#16]
Adding More Robust Validity Checks And Tests. 

Now when trying to create or update a vehicle with unsupported values e.g. -1  for Capacity or null for Type or Status there is a Error Popup and save is halted. See Attached Image

Tests for the Different Commands have also been added with situations like new vehicle, existing vehicle update, deleting a vehicle, and reloading. 

Tested flow using iOS 17 iPhone 15 simulator.

![image](https://github.com/user-attachments/assets/d919dfc1-af66-449b-b960-3d7205ba134c)


