### PR TITLE
 [#48] Add a "manage customers" page 

### DIFF
--- a/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
+++ b/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
@@ -15,5 +15,6 @@ namespace HaulageApp.Data
         public DbSet<Trip> trip { get; set; }
         public virtual DbSet<Vehicle> vehicle { get; set; }
         public virtual DbSet<Expense> expense { get; set; }
+        public DbSet<Role> role { get; set; }
     }
 }

--- a/HaulageApplication/HaulageApp/Models/Role.cs
+++ b/HaulageApplication/HaulageApp/Models/Role.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace HaulageApp.Models;
+
+[Table("role")]
+[PrimaryKey(nameof(Id))]
+public class Role
+{
+    public int Id { get; set; }
+    
+    [ForeignKey(nameof(Type))]
+    public string Type { get; set; }
+}

--- a/HaulageApplication/HaulageApp/ViewModels/ManageCustomersViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/ManageCustomersViewModel.cs
@@ -1,6 +1,113 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using HaulageApp.Data;
+using HaulageApp.Models;
+
 namespace HaulageApp.ViewModels;
 
-public class ManageCustomersViewModel
+public partial class ManageCustomersViewModel : ObservableObject
 {
+    private readonly HaulageDbContext _context;
+    private Role? _role;
+    private List<User> _allCustomers;
+    public ObservableCollection<User> Customers { get; } = [];
     
+    public ManageCustomersViewModel(HaulageDbContext dbContext)
+    {
+        _context = dbContext;
+        LoadAllCustomers();
+    }
+    
+    private string _customerIdOrEmail;
+    public string CustomerIdOrEmail
+    {
+        get => _customerIdOrEmail;
+        set
+        {
+            _customerIdOrEmail = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private void LoadAllCustomers()
+    {
+        _allCustomers = GetAllCustomers();
+        foreach (var customer in _allCustomers)
+        {
+            Customers.Add(customer);
+        }
+    }
+
+    private List<User> GetAllCustomers()
+    {
+        Role? customerRole = null;
+        
+        try
+        {
+           customerRole = _context.role
+                .FirstOrDefault(role => role.Type == "customer");
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            // could feed the UI some error about connection issues
+        }
+
+        if (customerRole != null)
+        {
+            try
+            {
+                var customers = _context.user
+                    .Where(user => user.Role == customerRole.Id)
+                    .ToList();
+                return customers;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                // as above
+            }
+        }
+        
+        return new List<User>();
+    }
+
+    [RelayCommand]
+    private void Search()
+    {
+        var customer = IdOrEmailMatchesCustomer();
+        if (customer != null)
+        {
+            Customers.Clear();
+            Customers.Add(customer);
+        }
+        else
+        {
+            Customers.Clear();
+        }
+    }
+
+    private User? IdOrEmailMatchesCustomer()
+    {
+        foreach (var customer in _allCustomers)
+        {
+            if (customer.Id.ToString() == CustomerIdOrEmail 
+                || customer.Email == CustomerIdOrEmail.ToLower())
+            {
+                return customer;
+            }
+        }
+        return null;
+    }
+    
+    [RelayCommand]
+    private void Clear()
+    {
+        Customers.Clear();
+        foreach (var customer in _allCustomers)
+        {
+            Customers.Add(customer);
+        }
+    }
 }

--- a/HaulageApplication/HaulageApp/Views/ManageCustomersPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/ManageCustomersPage.xaml
@@ -2,8 +2,53 @@
 
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="HaulageApp.Views.ManageCustomersPage">
-    <ContentPage.Content>
+    
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <toolkit:SelectedItemEventArgsConverter x:Key="SelectedItemEventArgsConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    
+    <VerticalStackLayout Spacing="10" Margin="10">
+        <Label Text="Search for Customer Email or ID"
+               FontAttributes="Bold"
+               FontSize="10"/>
         
-    </ContentPage.Content>
+        <Frame StyleClass="InputFrame">
+            <Editor x:Name="TextEditor"
+                    Placeholder="Enter customer email or ID"
+                    Text="{Binding CustomerIdOrEmail}"
+                    />
+        </Frame>
+        <Grid ColumnDefinitions="*,*" ColumnSpacing="4">
+            <Button Text="Search"
+                    Command="{Binding SearchCommand}"/>
+
+            <Button Grid.Column="1"
+                    Text="Clear"
+                    Command="{Binding ClearCommand}"/>
+        </Grid>
+        
+        <ListView
+            x:Name="customerList"
+            ItemsSource="{Binding Customers}"
+            Margin="20"
+            SelectionMode="Single"
+            SelectedItem="{Binding Customer}">
+            <ListView.Behaviors>
+                <toolkit:EventToCommandBehavior
+                    EventName="ItemSelected"
+                    Command="{Binding SelectCustomerCommand}"
+                    EventArgsConverter="{StaticResource SelectedItemEventArgsConverter}" />
+            </ListView.Behaviors>
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <TextCell Text="{Binding Id}"
+                              Detail="{Binding Email}" />
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </VerticalStackLayout>
 </ContentPage>

--- a/HaulageApplication/HaulageAppTests/ManageCustomersTests.cs
+++ b/HaulageApplication/HaulageAppTests/ManageCustomersTests.cs
@@ -1,0 +1,58 @@
+using HaulageApp.Data;
+using HaulageApp.ViewModels;
+using Microsoft.IdentityModel.Tokens;
+
+namespace HaulageAppTests;
+
+public class ManageCustomersTests
+{
+    private readonly MockDb _db = new();
+    private readonly HaulageDbContext _context;
+    private readonly ManageCustomersViewModel _viewModel;
+    
+    public ManageCustomersTests()
+    {
+        var options = _db.CreateContextOptions();
+        _db.CreateContext(options);
+        _context = new HaulageDbContext(options); 
+        _viewModel = new ManageCustomersViewModel(_context);
+    }
+    
+    [Fact] public Task ViewShouldReturnAllCustomersOnLoad()
+    {
+            Assert.True(_viewModel.Customers.Count == 3);
+            return Task.CompletedTask;
+    }
+    
+    [Fact] public Task SearchShouldReturnCustomerForExistingUserEmail()
+    {
+            _viewModel.CustomerIdOrEmail = "customer";
+            _viewModel.SearchCommand.Execute(null);
+            Assert.True(_viewModel.Customers.Count == 1 && _viewModel.Customers.FirstOrDefault()?.Email == "customer");
+            return Task.CompletedTask;
+    }
+    
+    [Fact] public Task SearchShouldReturnCustomerForExistingUserId()
+    {
+            _viewModel.CustomerIdOrEmail = "4";
+            _viewModel.SearchCommand.Execute(null);
+            Assert.True(_viewModel.Customers[0].Id == 4);
+            return Task.CompletedTask;
+    }
+    
+    [Fact] public Task SearchShouldNotReturnCustomerForInvalidUserEmail()
+    {
+            _viewModel.CustomerIdOrEmail = "whoIsThis"; // doesn't exist
+            _viewModel.SearchCommand.Execute(null);
+            Assert.True(_viewModel.Customers.IsNullOrEmpty());
+            return Task.CompletedTask;
+    }
+    
+    [Fact] public Task SearchShouldNotReturnCustomerForInvalidUserId()
+    {
+            _viewModel.CustomerIdOrEmail = "2"; // a driver's id
+            _viewModel.SearchCommand.Execute(null);
+            Assert.True(_viewModel.Customers.IsNullOrEmpty());
+            return Task.CompletedTask;
+    }
+}

--- a/HaulageApplication/HaulageAppTests/MockDb.cs
+++ b/HaulageApplication/HaulageAppTests/MockDb.cs
@@ -9,7 +9,7 @@ public class MockDb
     public DbContextOptions CreateContextOptions()
     {
         var options = new DbContextOptionsBuilder<HaulageDbContext>()
-            .UseInMemoryDatabase(databaseName: "MockDB")
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()) //required because of how dotnet test runs the tests
             .Options;
 
         return options;
@@ -17,12 +17,25 @@ public class MockDb
 
     public void CreateContext(DbContextOptions options)
     {
-        // Insert seed data into the database using one instance of the context
         using var context = new HaulageDbContext(options);
+        
+        //role table
+        var customerRole = new Role { Type = "customer"};
+        var driverRole = new Role { Type = "driver" };
+        var adminRole = new Role { Type = "admin" };
+        context.role.Add(customerRole);
+        context.role.Add(driverRole);
+        context.role.Add(adminRole);
+
+        context.SaveChanges();
+        
         //user table
-        context.user.Add(new User { Email = "customer", Password = "1234", Status = "active", Role = 1 });
-        context.user.Add(new User { Email = "driver", Password = "1234", Status = "inactive", Role = 2 });
-        context.user.Add(new User { Email = "admin", Password = "1234", Status = "active", Role = 3 });
+        context.user.Add(new User { Email = "customer", Password = "1234", Status = "active", Role = customerRole.Id });
+        context.user.Add(new User { Email = "driver", Password = "1234", Status = "inactive", Role = driverRole.Id });
+        context.user.Add(new User { Email = "admin", Password = "1234", Status = "active", Role = adminRole.Id });
+        context.user.Add(new User { Email = "customer2", Password = "1234", Status = "active", Role = customerRole.Id });
+        context.user.Add(new User { Email = "customer3", Password = "1234", Status = "active", Role = customerRole.Id });
+        
         context.SaveChanges();
     }
 }

--- a/HaulageApplication/HaulageAppTests/PermissionsModelTests.cs
+++ b/HaulageApplication/HaulageAppTests/PermissionsModelTests.cs
@@ -7,55 +7,41 @@ public class PermissionsModelTests
 {
     private readonly MockDb _db = new();
     private FakePreferencesWrapper fakeStorage = new();
-    
+    private readonly HaulageDbContext _context;
+    private PermissionsViewModel _viewModel;
+
+    public PermissionsModelTests()
+    {
+        var options = _db.CreateContextOptions();
+        _db.CreateContext(options);
+        _context = new HaulageDbContext(options);
+        _viewModel = new PermissionsViewModel(_context, fakeStorage);
+    }
+
     [Fact]
     public void AssertPageVisibilityWhenUserIsCustomer()
     {
-        var options = _db.CreateContextOptions();
-        _db.CreateContext(options);
-
-        using (var context = new HaulageDbContext(options))
-        {
-            PermissionsViewModel permissionsViewModel = new PermissionsViewModel(context, fakeStorage);
-
-            fakeStorage.Set<string>("hasAuth", "customer");
-            permissionsViewModel.UpdateTabsForCurrentUser();
-            Assert.False(permissionsViewModel.ManageCustomersIsVisible);
-            Assert.False(permissionsViewModel.NotesIsVisible);
-        }
+        fakeStorage.Set<string>("hasAuth", "customer");
+        _viewModel.UpdateTabsForCurrentUser();
+        Assert.False(_viewModel.ManageCustomersIsVisible);
+        Assert.False(_viewModel.NotesIsVisible);
     }
-    
+
     [Fact]
     public void AssertPageVisibilityWhenUserIsDriver()
     {
-        var options = _db.CreateContextOptions();
-        _db.CreateContext(options);
-
-        using (var context = new HaulageDbContext(options))
-        {
-            PermissionsViewModel permissionsViewModel = new PermissionsViewModel(context, fakeStorage);
-
-            fakeStorage.Set<string>("hasAuth", "driver");
-            permissionsViewModel.UpdateTabsForCurrentUser();
-            Assert.False(permissionsViewModel.ManageCustomersIsVisible);
-            Assert.True(permissionsViewModel.NotesIsVisible);
-        }
+        fakeStorage.Set<string>("hasAuth", "driver");
+        _viewModel.UpdateTabsForCurrentUser();
+        Assert.False(_viewModel.ManageCustomersIsVisible);
+        Assert.True(_viewModel.NotesIsVisible);
     }
-    
+
     [Fact]
     public void AssertPageVisibilityWhenUserIsAdmin()
     {
-        var options = _db.CreateContextOptions();
-        _db.CreateContext(options);
-
-        using (var context = new HaulageDbContext(options))
-        {
-            PermissionsViewModel permissionsViewModel = new PermissionsViewModel(context, fakeStorage);
-
-            fakeStorage.Set<string>("hasAuth", "admin");
-            permissionsViewModel.UpdateTabsForCurrentUser();
-            Assert.True(permissionsViewModel.ManageCustomersIsVisible);
-            Assert.False(permissionsViewModel.NotesIsVisible);
-        }
+        fakeStorage.Set<string>("hasAuth", "admin");
+        _viewModel.UpdateTabsForCurrentUser();
+        Assert.True(_viewModel.ManageCustomersIsVisible);
+        Assert.False(_viewModel.NotesIsVisible);
     }
 }


### PR DESCRIPTION
Resolves #48 

Linked to #17 

Functionality added to "manage customers". 
- You can see the full list on load (id and email). 
- You can search for a customer by email or id
- You can clear your search

Testing:

- Tests added
- Also tested on simulator iOS 17, iPhone 15

To be followed up with #49, where selection of a customer for amendment is added.

Screenshots below
<img width="442" alt="Screenshot 2024-08-23 at 20 22 08" src="https://github.com/user-attachments/assets/aacb1e31-4830-47c4-836e-2375d426d910">
<img width="444" alt="Screenshot 2024-08-23 at 20 21 55" src="https://github.com/user-attachments/assets/ba8d521e-acd8-48bf-8acd-a89d4a2f7b83">
<img width="457" alt="Screenshot 2024-08-23 at 20 21 44" src="https://github.com/user-attachments/assets/cd2bd086-0e12-4090-a6c9-2268e9db5a94">
<img width="454" alt="Screenshot 2024-08-23 at 20 21 33" src="https://github.com/user-attachments/assets/12821751-d5dc-4601-8e1a-bf3262992f86">
