### PR TITLE
[#7] Introduce the ability to see bills (only for customers) 

### DIFF
--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -63,5 +63,13 @@
                 ContentTemplate="{DataTemplate views:SettingsPage}"
                 Route="settings" />
         </Tab>
+        
+        <Tab Title="Bills" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
+            <ShellContent
+                Title="Bills"
+                ContentTemplate="{DataTemplate views:AllBillsPage}"
+                IsVisible="{Binding BillsIsVisible}"
+                Route="bills" />
+        </Tab>
     </TabBar>
 </Shell>

--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -18,6 +18,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("settings", typeof(SettingsPage));
         Routing.RegisterRoute(nameof(VehiclePage), typeof(VehiclePage));
         Routing.RegisterRoute(nameof(EditExpensePage), typeof(EditExpensePage));
-        
+        Routing.RegisterRoute(nameof(AllBillsPage), typeof(AllBillsPage));
     }
 }

--- a/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
+++ b/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
@@ -15,5 +15,10 @@ namespace HaulageApp.Data
         public DbSet<Trip> trip { get; set; }
         public virtual DbSet<Vehicle> vehicle { get; set; }
         public virtual DbSet<Expense> expense { get; set; }
+        
+        public DbSet<Bill> bill { get; set; }
+        
+        public DbSet<Item> item { get; set; }
+
     }
 }

--- a/HaulageApplication/HaulageApp/MauiProgram.cs
+++ b/HaulageApplication/HaulageApp/MauiProgram.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.EntityFrameworkCore;
 using CommunityToolkit.Maui;
 using HaulageApp.Common;
+using HaulageApp.Services;
 
 namespace HaulageApp;
 
@@ -77,10 +78,13 @@ public static class MauiProgram
         builder.Services.AddTransient<AppShell>();
         builder.Services.AddSingleton<PermissionsViewModel>();
         
-        builder.Services.AddSingleton<AllBillsViewModel>();
-        builder.Services.AddSingleton<BillViewModel>();
+        builder.Services.AddSingleton<IBillService, BillService>();
+        builder.Services.AddSingleton<IUserService, UserService>();
+
+        builder.Services.AddTransient<AllBillsViewModel>();
         builder.Services.AddTransient<AllBillsPage>();
 
+ 
 #if DEBUG
         builder.Logging.AddDebug();
 #endif

--- a/HaulageApplication/HaulageApp/MauiProgram.cs
+++ b/HaulageApplication/HaulageApp/MauiProgram.cs
@@ -39,6 +39,9 @@ public static class MauiProgram
         
         builder.Services.AddDbContext<HaulageDbContext>(options => options.UseSqlServer(connectionString));
 
+        builder.Services.AddSingleton<LoginViewModel>();
+        builder.Services.AddTransient<LoginPage>();
+        
         builder.Services.AddSingleton<IPreferencesWrapper>(implementationFactory => new PreferencesWrapper());
         builder.Services.AddSingleton<INavigationService>(implementationFactory => new NavigationService());
                     
@@ -60,9 +63,6 @@ public static class MauiProgram
         builder.Services.AddTransient<SettingsViewModel>();
         builder.Services.AddTransient<SettingsPage>();
         
-        builder.Services.AddSingleton<LoginViewModel>();
-        builder.Services.AddTransient<LoginPage>();
-        
         builder.Services.AddSingleton<AllNotesPage>();
         builder.Services.AddTransient<NotePage>();
         
@@ -77,6 +77,10 @@ public static class MauiProgram
         builder.Services.AddTransient<AppShell>();
         builder.Services.AddSingleton<PermissionsViewModel>();
         
+        builder.Services.AddSingleton<AllBillsViewModel>();
+        builder.Services.AddSingleton<BillViewModel>();
+        builder.Services.AddTransient<AllBillsPage>();
+
 #if DEBUG
         builder.Logging.AddDebug();
 #endif

--- a/HaulageApplication/HaulageApp/Models/Bill.cs
+++ b/HaulageApplication/HaulageApp/Models/Bill.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using HaulageApp.Models;
+
+public class Bill
+{
+    [Column("bill_id")]
+    public int BillId { get; set; }
+
+    [Column("customer_id")]
+    public int CustomerId { get; set; }
+
+    public decimal Amount { get; set; }
+
+    public string Status { get; set; }
+
+    public virtual ICollection<Item> Items { get; set; } = new List<Item>(); // Ensure Items is never null
+}

--- a/HaulageApplication/HaulageApp/Models/Item.cs
+++ b/HaulageApplication/HaulageApp/Models/Item.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace HaulageApp.Models;
+
+[Table("item")]
+public class Item
+{
+    [Column("item_id")]
+    public int ItemId { get; set; }
+
+    [Column("trip_id")]
+    public int TripId { get; set; }
+
+    [Column("bill_id")]
+    public int BillId { get; set; }
+
+    [Column("pickup_location")]
+    public string PickupLocation { get; set; }
+
+    [Column("delivery_location")]
+    public string DeliveryLocation { get; set; }
+
+    [Column("status")]
+    public string Status { get; set; }
+}

--- a/HaulageApplication/HaulageApp/Services/BillService.cs
+++ b/HaulageApplication/HaulageApp/Services/BillService.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HaulageApp.Data;
+using HaulageApp.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace HaulageApp.Services
+{
+    public class BillService : IBillService
+    {
+        private readonly HaulageDbContext _context;
+
+        public BillService(HaulageDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<Bill>> GetBillsForCurrentUserAsync(int userId)
+        {
+            return await _context.bill
+                .Include(b => b.Items)
+                .Where(b => b.CustomerId == userId)
+                .ToListAsync();
+        }
+    }
+}

--- a/HaulageApplication/HaulageApp/Services/IBillService.cs
+++ b/HaulageApplication/HaulageApp/Services/IBillService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HaulageApp.Models;
+
+namespace HaulageApp.Services
+{
+    public interface IBillService
+    {
+        Task<List<Bill>> GetBillsForCurrentUserAsync(int userId);
+    }
+}

--- a/HaulageApplication/HaulageApp/Services/IUserService.cs
+++ b/HaulageApplication/HaulageApp/Services/IUserService.cs
@@ -1,0 +1,7 @@
+namespace HaulageApp.Services
+{
+    public interface IUserService
+    {
+        int GetCurrentUserId();
+    }
+}

--- a/HaulageApplication/HaulageApp/Services/UserService.cs
+++ b/HaulageApplication/HaulageApp/Services/UserService.cs
@@ -1,0 +1,12 @@
+using Microsoft.Maui.Storage;
+
+namespace HaulageApp.Services
+{
+    public class UserService : IUserService
+    {
+        public int GetCurrentUserId()
+        {
+            return Preferences.Get("currentUserId", 0);
+        }
+    }
+}

--- a/HaulageApplication/HaulageApp/ViewModels/AllBillsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/AllBillsViewModel.cs
@@ -1,0 +1,50 @@
+using System.Collections.ObjectModel;
+using HaulageApp.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HaulageApp.ViewModels
+{
+    public class AllBillsViewModel
+    {
+        public ObservableCollection<BillViewModel> AllBills { get; private set; }
+
+        private readonly HaulageDbContext _context;
+        private readonly ILogger<AllBillsViewModel> _logger;
+
+        public AllBillsViewModel(HaulageDbContext context, ILogger<AllBillsViewModel> logger)
+        {
+            _context = context;
+            _logger = logger;
+
+            int currentUserId = GetCurrentUserId();
+
+            try
+            {
+                if (currentUserId == 0)
+                {
+                    AllBills = new ObservableCollection<BillViewModel>(); 
+                    return;
+                }
+
+                var bills = _context.bill
+                    .Include(b => b.Items)
+                    .Where(b => b.CustomerId == currentUserId)  
+                    .ToList();
+
+                AllBills = new ObservableCollection<BillViewModel>(
+                    bills.Select(b => new BillViewModel(_context, b))
+                );
+            }
+            catch (Exception ex)
+            {
+                AllBills = new ObservableCollection<BillViewModel>();
+            }
+        }
+
+        protected virtual int GetCurrentUserId()
+        {
+            return Preferences.Get("currentUserId", 0); 
+        }
+    }
+}

--- a/HaulageApplication/HaulageApp/ViewModels/BillViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/BillViewModel.cs
@@ -1,6 +1,5 @@
-using HaulageApp.Models;
-using HaulageApp.Data;
 using System.Collections.ObjectModel;
+using HaulageApp.Models;
 
 namespace HaulageApp.ViewModels
 {
@@ -11,19 +10,12 @@ namespace HaulageApp.ViewModels
         public int BillId => Bill.BillId;
         public decimal Amount => Bill.Amount;
         public string Status => Bill.Status;
-        public ObservableCollection<Item> Items { get; } = new ObservableCollection<Item>();
+        public ObservableCollection<Item> Items { get; }
 
-        public BillViewModel(HaulageDbContext context, Bill bill)
+        public BillViewModel(Bill bill)
         {
             Bill = bill;
-
-            if (Bill.Items != null)
-            {
-                foreach (var item in Bill.Items)
-                {
-                    Items.Add(item);
-                }
-            }
+            Items = new ObservableCollection<Item>(bill.Items);
         }
     }
 }

--- a/HaulageApplication/HaulageApp/ViewModels/BillViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/BillViewModel.cs
@@ -1,0 +1,29 @@
+using HaulageApp.Models;
+using HaulageApp.Data;
+using System.Collections.ObjectModel;
+
+namespace HaulageApp.ViewModels
+{
+    public class BillViewModel
+    {
+        public Bill Bill { get; }
+
+        public int BillId => Bill.BillId;
+        public decimal Amount => Bill.Amount;
+        public string Status => Bill.Status;
+        public ObservableCollection<Item> Items { get; } = new ObservableCollection<Item>();
+
+        public BillViewModel(HaulageDbContext context, Bill bill)
+        {
+            Bill = bill;
+
+            if (Bill.Items != null)
+            {
+                foreach (var item in Bill.Items)
+                {
+                    Items.Add(item);
+                }
+            }
+        }
+    }
+}

--- a/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/LoginViewModel.cs
@@ -47,6 +47,8 @@ public partial class LoginViewModel : ObservableObject
             case true:
                 Preferences.Default.Set("hasAuth", Email);
                 // we could also set the role in user defaults here if needed 
+                Preferences.Set("currentUserId", User.Id);
+                Preferences.Set("currentUserRole", User.Role);
                 _permissionsViewModel.UpdateTabsForCurrentUser(User!.Role);
                 // as mentioned on LoadingPage, this should either be a page that all roles have access to,
                 // e.g. settings. Another option is to go to a different page based on which role is logged in.

--- a/HaulageApplication/HaulageApp/ViewModels/PermissionsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/PermissionsViewModel.cs
@@ -10,6 +10,7 @@ public partial class PermissionsViewModel : ObservableObject
     [ObservableProperty] private bool _manageCustomersIsVisible;
     // example (using notes)
     [ObservableProperty] private bool _notesIsVisible;
+    [ObservableProperty] private bool _billsIsVisible;
     
     private readonly HaulageDbContext _dbContext;
     private readonly IPreferencesWrapper _preferencesWrapper;
@@ -54,6 +55,7 @@ public partial class PermissionsViewModel : ObservableObject
                 // Customer (and anyone else)
                 NotesIsVisible = false;
                 ManageCustomersIsVisible = false;
+                BillsIsVisible = true;
                 break; 
             case 2:
                 // Driver

--- a/HaulageApplication/HaulageApp/Views/AllBillsPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/AllBillsPage.xaml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HaulageApp.Views.AllBillsPage"
+             Title="Bills">
+
+    <ScrollView>
+        <CollectionView x:Name="billCollection"
+                        ItemsSource="{Binding AllBills}"
+                        SelectionMode="None"
+                        Margin="10,20,10,20">
+            <CollectionView.ItemsLayout>
+                <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
+            </CollectionView.ItemsLayout>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Frame Padding="10" Margin="5" BorderColor="LightGray" CornerRadius="5" HasShadow="True">
+                        <VerticalStackLayout>
+                            <Label Text="Bill ID:" FontSize="Medium" FontAttributes="Bold" TextColor="Black"/>
+                            <Label Text="{Binding BillId}" FontSize="Medium" TextColor="Black"/>
+                            <Label Text="Amount:" FontSize="Medium" FontAttributes="Bold" TextColor="Black"/>
+                            <Label Text="{Binding Amount, StringFormat='{}{0:C}'}" FontSize="Medium" TextColor="Black"/>
+                            <Label Text="Status:" FontSize="Medium" FontAttributes="Bold" TextColor="Black"/>
+                            <Label Text="{Binding Status}" FontSize="Medium" TextColor="Black"/>
+
+                            <!-- Always show the items associated with the bill -->
+                            <VerticalStackLayout Spacing="5" Margin="0,10,0,0">
+                                <Label Text="Items:" FontSize="Medium" FontAttributes="Bold" TextColor="Black"/>
+                                <CollectionView ItemsSource="{Binding Items}">
+                                    <CollectionView.ItemsLayout>
+                                        <LinearItemsLayout Orientation="Vertical" ItemSpacing="5" />
+                                    </CollectionView.ItemsLayout>
+                                    <CollectionView.ItemTemplate>
+                                        <DataTemplate>
+                                            <VerticalStackLayout>
+                                                <Label Text="Pickup Location:" FontAttributes="Bold"/>
+                                                <Label Text="{Binding PickupLocation}" TextColor="Gray"/>
+                                                <Label Text="Delivery Location:" FontAttributes="Bold"/>
+                                                <Label Text="{Binding DeliveryLocation}" TextColor="Gray"/>
+                                                <Label Text="Status:" FontAttributes="Bold"/>
+                                                <Label Text="{Binding Status}" TextColor="Gray"/>
+                                            </VerticalStackLayout>
+                                        </DataTemplate>
+                                    </CollectionView.ItemTemplate>
+                                </CollectionView>
+                            </VerticalStackLayout>
+                        </VerticalStackLayout>
+                    </Frame>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </ScrollView>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/AllBillsPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/AllBillsPage.xaml.cs
@@ -1,17 +1,21 @@
 using HaulageApp.ViewModels;
+using Microsoft.Extensions.Logging;
 
 namespace HaulageApp.Views;
 
 public partial class AllBillsPage : ContentPage
 {
+    private readonly AllBillsViewModel _viewModel;
     public AllBillsPage(AllBillsViewModel viewModel)
     {
-        BindingContext = viewModel;
         InitializeComponent();
+        BindingContext = viewModel;
+        _viewModel = viewModel; 
     }
 
-    private void ContentPage_NavigatedTo(object sender, NavigatedToEventArgs e)
+    protected override async void OnAppearing()
     {
-        billCollection.SelectedItem = null;
+        base.OnAppearing();
+        await _viewModel.LoadBillsAsync();
     }
 }

--- a/HaulageApplication/HaulageApp/Views/AllBillsPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/AllBillsPage.xaml.cs
@@ -1,0 +1,17 @@
+using HaulageApp.ViewModels;
+
+namespace HaulageApp.Views;
+
+public partial class AllBillsPage : ContentPage
+{
+    public AllBillsPage(AllBillsViewModel viewModel)
+    {
+        BindingContext = viewModel;
+        InitializeComponent();
+    }
+
+    private void ContentPage_NavigatedTo(object sender, NavigatedToEventArgs e)
+    {
+        billCollection.SelectedItem = null;
+    }
+}

--- a/HaulageApplication/HaulageAppTests/AllBillsViewModelTests.cs
+++ b/HaulageApplication/HaulageAppTests/AllBillsViewModelTests.cs
@@ -1,24 +1,27 @@
 using HaulageApp.Data;
-using HaulageApp.Models;
+using HaulageApp.Services;
 using HaulageApp.ViewModels;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Moq.Protected;
-using Xunit;
 
 namespace HaulageAppTests
 {
     public class AllBillsViewModelTests
     {
         private readonly DbContextOptions<HaulageDbContext> _options;
+        private readonly Mock<IBillService> _billServiceMock;
+        private readonly Mock<IUserService> _userServiceMock;
         private readonly Mock<ILogger<AllBillsViewModel>> _loggerMock;
 
         public AllBillsViewModelTests()
         {
             _options = new DbContextOptionsBuilder<HaulageDbContext>()
-                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()) // Unique database for each test
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
                 .Options;
+
+            _billServiceMock = new Mock<IBillService>();
+            _userServiceMock = new Mock<IUserService>();
             _loggerMock = new Mock<ILogger<AllBillsViewModel>>();
         }
 
@@ -26,84 +29,67 @@ namespace HaulageAppTests
         {
             using (var context = new HaulageDbContext(_options))
             {
-                context.Database.EnsureDeleted(); // Clears the database
-                context.Database.EnsureCreated(); // Recreates the schema
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
             }
         }
 
         [Fact]
-        public void AllBillsViewModel_LoadsSingleBillForCurrentUser()
+        public async Task AllBillsViewModel_LoadsSingleBillForCurrentUser()
         {
-            // Arrange
             ClearDatabase();
             var userId = 1;
 
-            using (var context = new HaulageDbContext(_options))
+            var bills = new List<Bill>
             {
-                context.bill.AddRange(
-                    new Bill { BillId = 1, CustomerId = userId, Amount = 100, Status = "paid", Items = new List<Item>() },
-                    new Bill { BillId = 2, CustomerId = 2, Amount = 200, Status = "pending", Items = new List<Item>() }
-                );
-                context.SaveChanges();
-            }
+                SharedTestSetup.CreateBillWithItems(1, 100, "paid")
+            };
 
-            using (var context = new HaulageDbContext(_options))
-            {
-                var viewModelMock = new Mock<AllBillsViewModel>(context, _loggerMock.Object) { CallBase = true };
-                viewModelMock.Protected().Setup<int>("GetCurrentUserId").Returns(userId);
+            _userServiceMock.Setup(us => us.GetCurrentUserId()).Returns(userId);
+            _billServiceMock.Setup(bs => bs.GetBillsForCurrentUserAsync(userId)).ReturnsAsync(bills);
 
-                var viewModel = viewModelMock.Object;
+            var viewModel = new AllBillsViewModel(_billServiceMock.Object, _userServiceMock.Object, _loggerMock.Object);
 
-                // Assert
-                Assert.Single(viewModel.AllBills);
-                Assert.Equal(100, viewModel.AllBills[0].Amount);
-            }
+            await viewModel.LoadBillsAsync();
+
+            Assert.Single(viewModel.AllBills);
+            Assert.Equal(100, viewModel.AllBills[0].Amount);
         }
 
         [Fact]
-        public void AllBillsViewModel_LoadsNoBillsForCustomerWithNoBills()
+        public async Task AllBillsViewModel_LoadsNoBillsForCustomerWithNoBills()
         {
-            // Arrange
             ClearDatabase();
             var userId = 2;
 
-            using (var context = new HaulageDbContext(_options))
-            {
-                context.bill.AddRange(
-                    new Bill { BillId = 1, CustomerId = 1, Amount = 100, Status = "paid", Items = new List<Item>() }
-                );
-                context.SaveChanges();
-            }
+            var bills = new List<Bill>();
 
-            using (var context = new HaulageDbContext(_options))
-            {
-                var viewModelMock = new Mock<AllBillsViewModel>(context, _loggerMock.Object) { CallBase = true };
-                viewModelMock.Protected().Setup<int>("GetCurrentUserId").Returns(userId);
+            _userServiceMock.Setup(us => us.GetCurrentUserId()).Returns(userId);
+            _billServiceMock.Setup(bs => bs.GetBillsForCurrentUserAsync(userId)).ReturnsAsync(bills);
 
-                var viewModel = viewModelMock.Object;
-
-                // Assert
-                Assert.Empty(viewModel.AllBills); // No bills should be loaded for user ID 2
-            }
+            var viewModel = new AllBillsViewModel(_billServiceMock.Object, _userServiceMock.Object, _loggerMock.Object);
+            
+            await viewModel.LoadBillsAsync();
+            
+            Assert.Empty(viewModel.AllBills);
         }
 
         [Fact]
-        public void AllBillsViewModel_LoadsNoBillsWhenDatabaseIsEmpty()
+        public async Task AllBillsViewModel_LoadsNoBillsWhenDatabaseIsEmpty()
         {
-            // Arrange
             ClearDatabase();
             var userId = 3;
 
-            using (var context = new HaulageDbContext(_options))
-            {
-                var viewModelMock = new Mock<AllBillsViewModel>(context, _loggerMock.Object) { CallBase = true };
-                viewModelMock.Protected().Setup<int>("GetCurrentUserId").Returns(userId);
+            var bills = new List<Bill>();
 
-                var viewModel = viewModelMock.Object;
+            _userServiceMock.Setup(us => us.GetCurrentUserId()).Returns(userId);
+            _billServiceMock.Setup(bs => bs.GetBillsForCurrentUserAsync(userId)).ReturnsAsync(bills);
 
-                // Assert
-                Assert.Empty(viewModel.AllBills); // No bills should be loaded because the database is empty
-            }
+            var viewModel = new AllBillsViewModel(_billServiceMock.Object, _userServiceMock.Object, _loggerMock.Object);
+
+            await viewModel.LoadBillsAsync();
+
+            Assert.Empty(viewModel.AllBills);
         }
     }
 }

--- a/HaulageApplication/HaulageAppTests/AllBillsViewModelTests.cs
+++ b/HaulageApplication/HaulageAppTests/AllBillsViewModelTests.cs
@@ -1,0 +1,109 @@
+using HaulageApp.Data;
+using HaulageApp.Models;
+using HaulageApp.ViewModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace HaulageAppTests
+{
+    public class AllBillsViewModelTests
+    {
+        private readonly DbContextOptions<HaulageDbContext> _options;
+        private readonly Mock<ILogger<AllBillsViewModel>> _loggerMock;
+
+        public AllBillsViewModelTests()
+        {
+            _options = new DbContextOptionsBuilder<HaulageDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()) // Unique database for each test
+                .Options;
+            _loggerMock = new Mock<ILogger<AllBillsViewModel>>();
+        }
+
+        private void ClearDatabase()
+        {
+            using (var context = new HaulageDbContext(_options))
+            {
+                context.Database.EnsureDeleted(); // Clears the database
+                context.Database.EnsureCreated(); // Recreates the schema
+            }
+        }
+
+        [Fact]
+        public void AllBillsViewModel_LoadsSingleBillForCurrentUser()
+        {
+            // Arrange
+            ClearDatabase();
+            var userId = 1;
+
+            using (var context = new HaulageDbContext(_options))
+            {
+                context.bill.AddRange(
+                    new Bill { BillId = 1, CustomerId = userId, Amount = 100, Status = "paid", Items = new List<Item>() },
+                    new Bill { BillId = 2, CustomerId = 2, Amount = 200, Status = "pending", Items = new List<Item>() }
+                );
+                context.SaveChanges();
+            }
+
+            using (var context = new HaulageDbContext(_options))
+            {
+                var viewModelMock = new Mock<AllBillsViewModel>(context, _loggerMock.Object) { CallBase = true };
+                viewModelMock.Protected().Setup<int>("GetCurrentUserId").Returns(userId);
+
+                var viewModel = viewModelMock.Object;
+
+                // Assert
+                Assert.Single(viewModel.AllBills);
+                Assert.Equal(100, viewModel.AllBills[0].Amount);
+            }
+        }
+
+        [Fact]
+        public void AllBillsViewModel_LoadsNoBillsForCustomerWithNoBills()
+        {
+            // Arrange
+            ClearDatabase();
+            var userId = 2;
+
+            using (var context = new HaulageDbContext(_options))
+            {
+                context.bill.AddRange(
+                    new Bill { BillId = 1, CustomerId = 1, Amount = 100, Status = "paid", Items = new List<Item>() }
+                );
+                context.SaveChanges();
+            }
+
+            using (var context = new HaulageDbContext(_options))
+            {
+                var viewModelMock = new Mock<AllBillsViewModel>(context, _loggerMock.Object) { CallBase = true };
+                viewModelMock.Protected().Setup<int>("GetCurrentUserId").Returns(userId);
+
+                var viewModel = viewModelMock.Object;
+
+                // Assert
+                Assert.Empty(viewModel.AllBills); // No bills should be loaded for user ID 2
+            }
+        }
+
+        [Fact]
+        public void AllBillsViewModel_LoadsNoBillsWhenDatabaseIsEmpty()
+        {
+            // Arrange
+            ClearDatabase();
+            var userId = 3;
+
+            using (var context = new HaulageDbContext(_options))
+            {
+                var viewModelMock = new Mock<AllBillsViewModel>(context, _loggerMock.Object) { CallBase = true };
+                viewModelMock.Protected().Setup<int>("GetCurrentUserId").Returns(userId);
+
+                var viewModel = viewModelMock.Object;
+
+                // Assert
+                Assert.Empty(viewModel.AllBills); // No bills should be loaded because the database is empty
+            }
+        }
+    }
+}

--- a/HaulageApplication/HaulageAppTests/BillViewModelTests.cs
+++ b/HaulageApplication/HaulageAppTests/BillViewModelTests.cs
@@ -1,0 +1,67 @@
+using HaulageApp.Models;
+using HaulageApp.ViewModels;
+using System.Collections.Generic;
+using Xunit;
+
+public class BillViewModelTests
+{
+    [Fact]
+    public void BillViewModel_Constructor_SetsPropertiesCorrectly()
+    {
+        var bill = new Bill
+        {
+            BillId = 1,
+            Amount = 150.75m,
+            Status = "paid",
+            Items = new List<Item>
+            {
+                new Item { ItemId = 1, PickupLocation = "Loc A", DeliveryLocation = "Loc B", Status = "delivered" },
+                new Item { ItemId = 2, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending" }
+            }
+        };
+
+        var viewModel = new BillViewModel(null, bill);
+        
+        Assert.Equal(bill.BillId, viewModel.BillId);
+        Assert.Equal(bill.Amount, viewModel.Amount);
+        Assert.Equal(bill.Status, viewModel.Status);
+        Assert.Equal(2, viewModel.Items.Count);
+    }
+
+    [Fact]
+    public void BillViewModel_Constructor_InitializesItemsCollectionCorrectly()
+    {
+        var bill = new Bill
+        {
+            BillId = 2,
+            Amount = 200.00m,
+            Status = "pending",
+            Items = new List<Item>
+            {
+                new Item { ItemId = 1, PickupLocation = "Loc A", DeliveryLocation = "Loc B", Status = "delivered" },
+                new Item { ItemId = 2, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending" }
+            }
+        };
+        
+        var viewModel = new BillViewModel(null, bill);
+        
+        Assert.NotNull(viewModel.Items);
+        Assert.Equal(2, viewModel.Items.Count);
+    }
+
+    [Fact]
+    public void BillViewModel_Constructor_SetsEmptyItemsCollection_WhenItemsIsNull()
+    {
+        var bill = new Bill
+        {
+            BillId = 3,
+            Amount = 250.00m,
+            Status = "paid",
+            Items = null 
+        };
+        
+        var viewModel = new BillViewModel(null, bill);
+        
+        Assert.Empty(viewModel.Items);
+    }
+}

--- a/HaulageApplication/HaulageAppTests/BillViewModelTests.cs
+++ b/HaulageApplication/HaulageAppTests/BillViewModelTests.cs
@@ -1,26 +1,16 @@
 using HaulageApp.Models;
-using HaulageApp.ViewModels;
-using System.Collections.Generic;
-using Xunit;
-
 public class BillViewModelTests
 {
     [Fact]
     public void BillViewModel_Constructor_SetsPropertiesCorrectly()
     {
-        var bill = new Bill
+        var bill = SharedTestSetup.CreateBillWithItems(1, 150.75m, "paid", new List<Item>
         {
-            BillId = 1,
-            Amount = 150.75m,
-            Status = "paid",
-            Items = new List<Item>
-            {
-                new Item { ItemId = 1, PickupLocation = "Loc A", DeliveryLocation = "Loc B", Status = "delivered" },
-                new Item { ItemId = 2, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending" }
-            }
-        };
+            new Item { ItemId = 1, PickupLocation = "Loc A", DeliveryLocation = "Loc B", Status = "delivered" },
+            new Item { ItemId = 2, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending" }
+        });
 
-        var viewModel = new BillViewModel(null, bill);
+        var viewModel = SharedTestSetup.CreateBillViewModel(bill);
         
         Assert.Equal(bill.BillId, viewModel.BillId);
         Assert.Equal(bill.Amount, viewModel.Amount);
@@ -31,37 +21,55 @@ public class BillViewModelTests
     [Fact]
     public void BillViewModel_Constructor_InitializesItemsCollectionCorrectly()
     {
-        var bill = new Bill
+        var bill = SharedTestSetup.CreateBillWithItems(2, 200.00m, "pending", new List<Item>
         {
-            BillId = 2,
-            Amount = 200.00m,
-            Status = "pending",
-            Items = new List<Item>
-            {
-                new Item { ItemId = 1, PickupLocation = "Loc A", DeliveryLocation = "Loc B", Status = "delivered" },
-                new Item { ItemId = 2, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending" }
-            }
-        };
+            new Item { ItemId = 1, PickupLocation = "Loc A", DeliveryLocation = "Loc B", Status = "delivered" },
+            new Item { ItemId = 2, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending" }
+        });
         
-        var viewModel = new BillViewModel(null, bill);
+        var viewModel = SharedTestSetup.CreateBillViewModel(bill);
         
         Assert.NotNull(viewModel.Items);
         Assert.Equal(2, viewModel.Items.Count);
     }
+    
+    [Fact]
+    public void BillViewModel_Constructor_InitializesEmptyItemsCollectionCorrectly()
+    {
+        var bill = SharedTestSetup.CreateBillWithItems(3, 300.00m, "pending", new List<Item>());
+
+        var viewModel = SharedTestSetup.CreateBillViewModel(bill);
+
+        Assert.NotNull(viewModel.Items);
+        Assert.Empty(viewModel.Items);
+    }
+    
+    [Fact]
+    public void BillViewModel_Constructor_HandlesMultipleItemsCorrectly()
+    {
+        var bill = SharedTestSetup.CreateBillWithItems(5, 500.00m, "pending", new List<Item>
+        {
+            new Item { ItemId = 1, PickupLocation = "Loc A", DeliveryLocation = "Loc B", Status = "delivered" },
+            new Item { ItemId = 2, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending" },
+            new Item { ItemId = 3, PickupLocation = "Loc E", DeliveryLocation = "Loc F", Status = "pending" }
+        });
+
+        var viewModel = SharedTestSetup.CreateBillViewModel(bill);
+
+        Assert.Equal(3, viewModel.Items.Count);
+        Assert.Equal("Loc A", viewModel.Items[0].PickupLocation);
+        Assert.Equal("Loc C", viewModel.Items[1].PickupLocation);
+        Assert.Equal("Loc E", viewModel.Items[2].PickupLocation);
+    }
 
     [Fact]
-    public void BillViewModel_Constructor_SetsEmptyItemsCollection_WhenItemsIsNull()
+    public void BillViewModel_Constructor_HandlesNullItemsCollectionCorrectly()
     {
-        var bill = new Bill
-        {
-            BillId = 3,
-            Amount = 250.00m,
-            Status = "paid",
-            Items = null 
-        };
-        
-        var viewModel = new BillViewModel(null, bill);
-        
+        var bill = SharedTestSetup.CreateBillWithItems(4, 400.00m, "paid", null);
+
+        var viewModel = SharedTestSetup.CreateBillViewModel(bill);
+
+        Assert.NotNull(viewModel.Items); 
         Assert.Empty(viewModel.Items);
     }
 }

--- a/HaulageApplication/HaulageAppTests/SharedTestSetup.cs
+++ b/HaulageApplication/HaulageAppTests/SharedTestSetup.cs
@@ -1,0 +1,23 @@
+// SharedTestSetup.cs
+using HaulageApp.Models;
+using System.Collections.Generic;
+using HaulageApp.ViewModels;
+
+public static class SharedTestSetup
+{
+    public static Bill CreateBillWithItems(int billId, decimal amount, string status, List<Item> items = null)
+    {
+        return new Bill
+        {
+            BillId = billId,
+            Amount = amount,
+            Status = status,
+            Items = items ?? new List<Item>()
+        };
+    }
+
+    public static BillViewModel CreateBillViewModel(Bill bill)
+    {
+        return new BillViewModel(bill);
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/MxmIv/SET09402_Haulage/issues/7

This this a change to Introduce the ability to see bills (only for customers) 

Customers will be able to see their bills. Different customers will not see each others bills. 
**Example for one customer:** 
![Screenshot 2024-08-23 at 23 04 42](https://github.com/user-attachments/assets/800fb4c9-1101-42e4-a579-aa60dc0e095d)
![Screenshot 2024-08-23 at 23 04 46](https://github.com/user-attachments/assets/0693202b-85c7-4ea7-b080-54e18088ddaa)
**Example for second customer:** 
![Screenshot 2024-08-23 at 23 05 28](https://github.com/user-attachments/assets/fa3ee314-c4d7-4a79-a1c5-a577fec06e11)
![Screenshot 2024-08-23 at 23 05 33](https://github.com/user-attachments/assets/701dfec8-831e-4247-b839-95075061164a)
**Example the page is not visible for non customer:** 
![Screenshot 2024-08-23 at 23 06 20](https://github.com/user-attachments/assets/910dc85c-f760-40eb-ba7c-d7ef534598bf)

Testing: 
- Ran all the existing unit test 
- Tested locally using iPhone 155 (iOS 17.4) emulator 
- Added additional tests to test added view models 


Notes:  
- It seems like we have a bug, that when we logout and log back in as another user, the old used is still appears to be logged in, there is already a ticket related to that https://github.com/MxmIv/SET09402_Haulage/issues/51



