### PR TITLE
#22 Introduce ability for admin to check trips (keeping manage expenses, …

### DIFF
--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -46,6 +46,8 @@
             <ShellContent
                 Title="Trip"
                 ContentTemplate="{DataTemplate views:TripPage}"
+                IsVisible="{Binding TripsIsVisible}"
+
                 Route="trip"/>
         </Tab>
         

--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -21,5 +21,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(EditExpensePage), typeof(EditExpensePage));
         Routing.RegisterRoute(nameof(AllBillsPage), typeof(AllBillsPage));
         Routing.RegisterRoute(nameof(EventPage), typeof(EventPage));
+        Routing.RegisterRoute(nameof(TripPage), typeof(TripPage));
     }
 }

--- a/HaulageApplication/HaulageApp/MauiProgram.cs
+++ b/HaulageApplication/HaulageApp/MauiProgram.cs
@@ -78,7 +78,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<AllVehiclesViewModel>();
         builder.Services.AddTransient<VehicleViewModel>();
         
-        builder.Services.AddSingleton<TripViewModel>();
+        builder.Services.AddTransient<TripViewModel>();
         builder.Services.AddTransient<TripPage>();
 
         builder.Services.AddTransient<AppShell>();

--- a/HaulageApplication/HaulageApp/Services/IUserService.cs
+++ b/HaulageApplication/HaulageApp/Services/IUserService.cs
@@ -2,6 +2,7 @@ namespace HaulageApp.Services
 {
     public interface IUserService
     {
+        bool IsDriver();
         int GetCurrentUserId();
     }
 }

--- a/HaulageApplication/HaulageApp/Services/UserService.cs
+++ b/HaulageApplication/HaulageApp/Services/UserService.cs
@@ -1,9 +1,24 @@
+using HaulageApp.Data;
 using Microsoft.Maui.Storage;
 
 namespace HaulageApp.Services
 {
     public class UserService : IUserService
     {
+        private readonly HaulageDbContext _context;
+
+        public UserService(HaulageDbContext context)
+        {
+            _context = context;
+        }
+
+        public bool IsDriver()
+        {
+            var currentUserId = GetCurrentUserId();
+            var user = _context.user.FirstOrDefault(u => u.Id == currentUserId);
+            return user != null && user.Role == 2; 
+        }
+
         public int GetCurrentUserId()
         {
             return Preferences.Get("currentUserId", 0);

--- a/HaulageApplication/HaulageApp/ViewModels/PermissionsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/PermissionsViewModel.cs
@@ -11,7 +11,8 @@ public partial class PermissionsViewModel : ObservableObject
     // example (using notes)
     [ObservableProperty] private bool _notesIsVisible;
     [ObservableProperty] private bool _billsIsVisible;
-    
+    [ObservableProperty] private bool _tripsIsVisible;
+
     private readonly HaulageDbContext _dbContext;
     private readonly IPreferencesWrapper _preferencesWrapper;
 
@@ -56,16 +57,21 @@ public partial class PermissionsViewModel : ObservableObject
                 NotesIsVisible = false;
                 ManageCustomersIsVisible = false;
                 BillsIsVisible = true;
+                TripsIsVisible = false;
                 break; 
             case 2:
                 // Driver
                 NotesIsVisible = true;
                 ManageCustomersIsVisible = false;
+                BillsIsVisible = false;
+                TripsIsVisible = true;
                 break;
             case 3:
                 // Admin
                 NotesIsVisible = false;
                 ManageCustomersIsVisible = true;
+                BillsIsVisible = false;
+                TripsIsVisible = true;
                 break;
         }
     }

--- a/HaulageApplication/HaulageApp/ViewModels/TripItemViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/TripItemViewModel.cs
@@ -11,32 +11,33 @@ namespace HaulageApp.ViewModels
     public class TripItemViewModel : INotifyPropertyChanged
     {
         private readonly HaulageDbContext _context;
+        private readonly bool _canEdit;
         private Trip _trip;
         private bool _isEditing;
 
         private string _tempStartTimeString;
         private string _tempEndTimeString;
-        
+
         public ICommand GoToExpensesCommand { get; set; }
         public ICommand GoToEventsCommand { get; set; }
 
-        public TripItemViewModel(Trip trip, HaulageDbContext context)
+        public TripItemViewModel(Trip trip, HaulageDbContext context, bool canEdit)
         {
             _trip = trip;
             _context = context;
-
+            _canEdit = canEdit;
+            
             _tempStartTimeString = _trip.StartTime.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
             _tempEndTimeString = _trip.EndTime?.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) ?? string.Empty;
-
+            
             ToggleEditCommand = new Command(async () =>
             {
-                if (IsEditing)
+                if (IsEditing && _canEdit)
                 {
                     await SaveTrip();
                 }
 
                 IsEditing = !IsEditing;
-
                 OnPropertyChanged(nameof(EditSaveButtonText));
                 OnPropertyChanged(nameof(IsEditing));
             });
@@ -46,12 +47,6 @@ namespace HaulageApp.ViewModels
         }
 
         public int TripId => _trip.Id;
-        
-        private async Task GoToExpensesAsync()
-        {
-            await Shell.Current.GoToAsync("expenses",
-                new Dictionary<string, object> { { "trip", _trip } });
-        }
         
         private async Task GoToEventsAsync()
         {
@@ -102,14 +97,14 @@ namespace HaulageApp.ViewModels
 
         public bool IsEditing
         {
-            get => _isEditing;
+            get => _isEditing && _canEdit;
             set
             {
                 if (_isEditing != value)
                 {
                     _isEditing = value;
                     OnPropertyChanged(nameof(IsEditing));
-                    OnPropertyChanged(nameof(EditSaveButtonText)); // Notify change here to update button text
+                    OnPropertyChanged(nameof(EditSaveButtonText));
                 }
             }
         }
@@ -171,6 +166,13 @@ namespace HaulageApp.ViewModels
                 }
             }
         }
+
+        private async Task GoToExpensesAsync()
+        {
+            await Shell.Current.GoToAsync("expenses", new Dictionary<string, object> { { "trip", _trip } });
+        }
+        
+        public bool IsEditButtonVisible => _canEdit;
 
         public event PropertyChangedEventHandler? PropertyChanged;
 

--- a/HaulageApplication/HaulageApp/Views/TripPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/TripPage.xaml
@@ -43,6 +43,7 @@
                                 <Button 
                                     Text="{Binding EditSaveButtonText}" 
                                     Command="{Binding ToggleEditCommand}"
+                                    IsVisible="{Binding IsEditButtonVisible}"
                                     FontSize="16"
                                 />
                                 <Button

--- a/HaulageApplication/HaulageApp/Views/TripPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/TripPage.xaml.cs
@@ -4,10 +4,22 @@ namespace HaulageApp.Views
 {
     public partial class TripPage : ContentPage
     {
+        private readonly TripViewModel _viewModel;
+
         public TripPage(TripViewModel viewModel)
         {
-            BindingContext = viewModel;
             InitializeComponent();
+            _viewModel = viewModel;
+            BindingContext = _viewModel;
+        }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            if (_viewModel != null)
+            {
+                await _viewModel.LoadDataAsync();
+            }
         }
     }
 }

--- a/HaulageApplication/HaulageAppTests/MockDb.cs
+++ b/HaulageApplication/HaulageAppTests/MockDb.cs
@@ -6,7 +6,7 @@ namespace HaulageAppTests;
 
 public class MockDb
 {
-    public DbContextOptions CreateContextOptions()
+    public DbContextOptions<HaulageDbContext> CreateContextOptions()
     {
         var options = new DbContextOptionsBuilder<HaulageDbContext>()
             .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()) //required because of how dotnet test runs the tests
@@ -15,10 +15,28 @@ public class MockDb
         return options;
     }
 
-    public void CreateContext(DbContextOptions options)
+    public void CreateContext(DbContextOptions<HaulageDbContext> options)
     {
         using var context = new HaulageDbContext(options);
+        //role table
+        var customerRole = new Role { Type = "customer"};
+        var driverRole = new Role { Type = "driver" };
+        var adminRole = new Role { Type = "admin" };
+        context.role.Add(customerRole);
+        context.role.Add(driverRole);
+        context.role.Add(adminRole);
         
+        context.user.Add(new User { Email = "customer", Password = "1234", Status = "active", Role = customerRole.Id });
+        context.user.Add(new User { Email = "driver", Password = "1234", Status = "inactive", Role = driverRole.Id });
+        context.user.Add(new User { Email = "admin", Password = "1234", Status = "active", Role = adminRole.Id });
+        context.user.Add(new User { Email = "customer2", Password = "1234", Status = "active", Role = customerRole.Id });
+        context.user.Add(new User { Email = "customer3", Password = "1234", Status = "active", Role = customerRole.Id });
+        context.SaveChanges();
+    }
+
+    public void CreateContextWithTrips(DbContextOptions<HaulageDbContext> options)
+    {
+        using var context = new HaulageDbContext(options);
         //role table
         var customerRole = new Role { Type = "customer"};
         var driverRole = new Role { Type = "driver" };
@@ -28,14 +46,25 @@ public class MockDb
         context.role.Add(adminRole);
 
         context.SaveChanges();
-        
         //user table
         context.user.Add(new User { Email = "customer", Password = "1234", Status = "active", Role = customerRole.Id });
         context.user.Add(new User { Email = "driver", Password = "1234", Status = "inactive", Role = driverRole.Id });
         context.user.Add(new User { Email = "admin", Password = "1234", Status = "active", Role = adminRole.Id });
         context.user.Add(new User { Email = "customer2", Password = "1234", Status = "active", Role = customerRole.Id });
         context.user.Add(new User { Email = "customer3", Password = "1234", Status = "active", Role = customerRole.Id });
-        
+
+        context.trip.AddRange(
+            new Trip { Id = 1, StartTime = DateTime.Now.AddHours(-2), Status = "ongoing" },
+            new Trip { Id = 2, StartTime = DateTime.Now.AddHours(-4), Status = "completed" }
+        );
+
         context.SaveChanges();
+    }
+
+    public void ClearDatabase(DbContextOptions<HaulageDbContext> options)
+    {
+        using var context = new HaulageDbContext(options);
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
     }
 }

--- a/HaulageApplication/HaulageAppTests/SharedTestSetup.cs
+++ b/HaulageApplication/HaulageAppTests/SharedTestSetup.cs
@@ -1,4 +1,3 @@
-// SharedTestSetup.cs
 using HaulageApp.Models;
 using System.Collections.Generic;
 using HaulageApp.ViewModels;

--- a/HaulageApplication/HaulageAppTests/TripItemViewModelTests.cs
+++ b/HaulageApplication/HaulageAppTests/TripItemViewModelTests.cs
@@ -2,29 +2,53 @@ using Moq;
 using HaulageApp.ViewModels;
 using HaulageApp.Data;
 using HaulageApp.Models;
+using HaulageApp.Services;
 using Microsoft.EntityFrameworkCore;
+using Xunit;
 
-namespace HaulageApp.Tests
+namespace HaulageAppTests
 {
-    public class TripItemViewModelTests
+    public class TripItemViewModelTests : IAsyncLifetime
     {
-        [Fact]
-        public async Task SaveTrip_ShouldUpdateDatabase_WhenCalled()
+        private Mock<IUserService> _userServiceMock;
+        private MockDb _mockDb;
+        private DbContextOptions<HaulageDbContext> _options;
+
+        public TripItemViewModelTests()
         {
-            var mockContext = new Mock<HaulageDbContext>(new DbContextOptions<HaulageDbContext>());
-            var trip = new Trip
-            {
-                Id = 1,
-                StartTime = DateTime.Parse("2024-08-19 08:00"),
-                EndTime = null,
-                Status = "ongoing",
-                UpdatedAt = DateTime.Now
-            };
-            var viewModel = new TripItemViewModel(trip, mockContext.Object, true)
-            {
-                StartTimeString = "2024-08-19 09:00",
-                EndTimeString = "2024-08-19 12:00"
-            };
+            _userServiceMock = new Mock<IUserService>();
+            _mockDb = new MockDb();
+            _options = _mockDb.CreateContextOptions();
+        }
+
+        public Task InitializeAsync()
+        {
+            _mockDb.ClearDatabase(_options);
+            return Task.CompletedTask;
+        }
+
+        public Task DisposeAsync()
+        {
+            _mockDb.ClearDatabase(_options);
+            return Task.CompletedTask;
+        }
+
+        private TripItemViewModel CreateTripItemViewModel(Trip trip, bool canEdit)
+        {
+            return new TripItemViewModel(trip, new HaulageDbContext(_options), canEdit);
+        }
+
+        [Fact]
+        public async Task TripItemViewModel_SaveTrip_ShouldUpdateDatabase_WhenCalled()
+        {
+            _mockDb.CreateContextWithTrips(_options);
+
+            using var context = new HaulageDbContext(_options);
+            var trip = await context.trip.FirstOrDefaultAsync(t => t.Id == 1);
+
+            var viewModel = CreateTripItemViewModel(trip, canEdit: true);
+            viewModel.StartTimeString = "2024-08-19 09:00";
+            viewModel.EndTimeString = "2024-08-19 12:00";
 
             await viewModel.SaveTrip();
 
@@ -32,71 +56,48 @@ namespace HaulageApp.Tests
         }
 
         [Fact]
-        public async Task SaveTrip_ShouldChangeStatus_WhenEndTimeIsNotDefinedButUpdatedAtWasChanged()
+        public async Task TripItemViewModel_SaveTrip_ShouldChangeStatus_WhenEndTimeIsNotDefinedButUpdatedAtWasChanged()
         {
-            var mockContext = new Mock<HaulageDbContext>(new DbContextOptions<HaulageDbContext>());
-            var trip = new Trip
-            {
-                Id = 1,
-                StartTime = DateTime.Parse("2024-08-19 08:00"),
-                EndTime = null, // No end time
-                Status = "planned",
-                UpdatedAt = DateTime.Now
-            };
-            
-            var viewModel = new TripItemViewModel(trip, mockContext.Object, true)
-            {
-                StartTimeString = trip.StartTime.ToString("yyyy-MM-dd HH:mm"),
-                EndTimeString = "" // No changes made to EndTime
-            };
+            _mockDb.CreateContextWithTrips(_options);
+
+            using var context = new HaulageDbContext(_options);
+            var trip = await context.trip.FirstOrDefaultAsync(t => t.Id == 1);
+
+            var viewModel = CreateTripItemViewModel(trip, canEdit: true);
+            viewModel.StartTimeString = trip.StartTime.ToString("yyyy-MM-dd HH:mm");
+            viewModel.EndTimeString = ""; // No changes made to EndTime
+
             await viewModel.SaveTrip();
-            
-            Assert.Equal("ongoing", viewModel.Status); // Status should remain as "planned"
+
+            Assert.Equal("ongoing", viewModel.Status); // Status should remain as "ongoing"
         }
 
         [Fact]
-        public async Task SaveTrip_ShouldNotUpdateDatabase_WhenNoChangesMade()
+        public async Task TripItemViewModel_SaveTrip_ShouldNotUpdateDatabase_WhenNoChangesMade()
         {
-            var mockContext = new Mock<HaulageDbContext>(new DbContextOptions<HaulageDbContext>());
-            var trip = new Trip
-            {
-                Id = 1,
-                StartTime = DateTime.Parse("2024-08-19 08:00"),
-                EndTime = DateTime.Parse("2024-08-19 12:00"),
-                Status = "completed",
-                UpdatedAt = DateTime.Now
-            };
+            _mockDb.CreateContextWithTrips(_options);
 
-            mockContext.Setup(c => c.Attach(It.IsAny<Trip>())).Verifiable();
-            mockContext.Setup(c => c.Update(It.IsAny<Trip>())).Verifiable();
-            mockContext.Setup(c => c.SaveChangesAsync(default)).ReturnsAsync(1);
+            using var context = new HaulageDbContext(_options);
+            var trip = await context.trip.FirstOrDefaultAsync(t => t.Id == 1);
 
-            var viewModel = new TripItemViewModel(trip, mockContext.Object, true)
-            {
-                StartTimeString = "2024-08-19 08:00",
-                EndTimeString = "2024-08-19 12:00"
-            };
+            var viewModel = CreateTripItemViewModel(trip, canEdit: true);
+            viewModel.StartTimeString = trip.StartTime.ToString("yyyy-MM-dd HH:mm");
+            viewModel.EndTimeString = trip.EndTime?.ToString("yyyy-MM-dd HH:mm") ?? string.Empty;
+
             await viewModel.SaveTrip();
 
-            mockContext.Verify(c => c.Attach(It.IsAny<Trip>()), Times.Never);
-            mockContext.Verify(c => c.Update(It.IsAny<Trip>()), Times.Never);
-            mockContext.Verify(c => c.SaveChangesAsync(default), Times.Never);
+            Assert.Equal(trip.Status, viewModel.Status); // Status should remain the same
         }
-        
-        [Fact]
-        public void ToggleEditCommand_ShouldToggleIsEditing_WhenExecuted()
-        {
-            var mockContext = new Mock<HaulageDbContext>(new DbContextOptions<HaulageDbContext>());
-            var trip = new Trip
-            {
-                Id = 1,
-                StartTime = DateTime.Parse("2024-08-19 08:00"),
-                EndTime = DateTime.Parse("2024-08-19 12:00"),
-                Status = "completed",
-                UpdatedAt = DateTime.Now
-            };
 
-            var viewModel = new TripItemViewModel(trip, mockContext.Object, true);
+        [Fact]
+        public void TripItemViewModel_ToggleEditCommand_ShouldToggleIsEditing_WhenExecuted()
+        {
+            _mockDb.CreateContextWithTrips(_options);
+
+            using var context = new HaulageDbContext(_options);
+            var trip = context.trip.FirstOrDefault(t => t.Id == 1);
+
+            var viewModel = CreateTripItemViewModel(trip, canEdit: true);
 
             Assert.False(viewModel.IsEditing); // Initially not editing
             viewModel.ToggleEditCommand.Execute(null);
@@ -108,17 +109,12 @@ namespace HaulageApp.Tests
         [Fact]
         public void TripItemViewModel_IsDriver_ShouldAllowEditing_ForDrivers()
         {
-            var mockContext = new Mock<HaulageDbContext>(new DbContextOptions<HaulageDbContext>());
-            var trip = new Trip
-            {
-                Id = 1,
-                StartTime = DateTime.Parse("2024-08-19 08:00"),
-                EndTime = DateTime.Parse("2024-08-19 12:00"),
-                Status = "completed",
-                UpdatedAt = DateTime.Now
-            };
+            _mockDb.CreateContextWithTrips(_options);
 
-            var viewModel = new TripItemViewModel(trip, mockContext.Object, true); // true indicates the user is a driver
+            using var context = new HaulageDbContext(_options);
+            var trip = context.trip.FirstOrDefault(t => t.Id == 1);
+
+            var viewModel = CreateTripItemViewModel(trip, canEdit: true); // true indicates the user is a driver
 
             Assert.True(viewModel.IsEditButtonVisible); // Drivers can edit
         }
@@ -126,17 +122,12 @@ namespace HaulageApp.Tests
         [Fact]
         public void TripItemViewModel_IsAdmin_ShouldNotAllowEditing_ForAdmins()
         {
-            var mockContext = new Mock<HaulageDbContext>(new DbContextOptions<HaulageDbContext>());
-            var trip = new Trip
-            {
-                Id = 1,
-                StartTime = DateTime.Parse("2024-08-19 08:00"),
-                EndTime = DateTime.Parse("2024-08-19 12:00"),
-                Status = "completed",
-                UpdatedAt = DateTime.Now
-            };
+            _mockDb.CreateContextWithTrips(_options);
 
-            var viewModel = new TripItemViewModel(trip, mockContext.Object, false); // false indicates the user is not a driver (admin)
+            using var context = new HaulageDbContext(_options);
+            var trip = context.trip.FirstOrDefault(t => t.Id == 1);
+
+            var viewModel = CreateTripItemViewModel(trip, canEdit: false); // false indicates the user is not a driver (admin)
 
             Assert.False(viewModel.IsEditButtonVisible); // Admins cannot edit
         }

--- a/HaulageApplication/HaulageAppTests/TripViewModelTests.cs
+++ b/HaulageApplication/HaulageAppTests/TripViewModelTests.cs
@@ -1,0 +1,98 @@
+using Moq;
+using HaulageApp.ViewModels;
+using HaulageApp.Data;
+using HaulageApp.Models;
+using HaulageApp.Services;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.ObjectModel;
+
+namespace HaulageApp.Tests
+{
+    public class TripViewModelTests
+    {
+        private readonly Mock<IUserService> _userServiceMock;
+        private readonly DbContextOptions<HaulageDbContext> _options;
+
+        public TripViewModelTests()
+        {
+            _userServiceMock = new Mock<IUserService>();
+            _options = new DbContextOptionsBuilder<HaulageDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+        }
+
+        private void ClearDatabase()
+        {
+            using (var context = new HaulageDbContext(_options))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+            }
+        }
+
+        [Fact]
+        public async Task TripViewModel_LoadsDataAsync_ForDriver()
+        {
+            ClearDatabase();
+
+            using (var context = new HaulageDbContext(_options))
+            {
+                context.trip.AddRange(
+                    new Trip { Id = 1, StartTime = DateTime.Now.AddHours(-2), Status = "ongoing" },
+                    new Trip { Id = 2, StartTime = DateTime.Now.AddHours(-4), Status = "completed" }
+                );
+                await context.SaveChangesAsync();
+            }
+
+            _userServiceMock.Setup(us => us.IsDriver()).Returns(true);
+
+            var viewModel = new TripViewModel(new HaulageDbContext(_options), _userServiceMock.Object);
+
+            await viewModel.LoadDataAsync();
+
+            Assert.NotNull(viewModel.TripGroups);
+            Assert.Equal(2, viewModel.TripGroups.Count);
+            Assert.All(viewModel.TripGroups, t => Assert.True(t.IsEditButtonVisible));
+        }
+
+        [Fact]
+        public async Task TripViewModel_LoadsDataAsync_ForAdmin()
+        {
+            ClearDatabase();
+
+            using (var context = new HaulageDbContext(_options))
+            {
+                context.trip.AddRange(
+                    new Trip { Id = 1, StartTime = DateTime.Now.AddHours(-2), Status = "ongoing" },
+                    new Trip { Id = 2, StartTime = DateTime.Now.AddHours(-4), Status = "completed" }
+                );
+                await context.SaveChangesAsync();
+            }
+
+            _userServiceMock.Setup(us => us.IsDriver()).Returns(false);
+
+            var viewModel = new TripViewModel(new HaulageDbContext(_options), _userServiceMock.Object);
+
+            await viewModel.LoadDataAsync();
+
+            Assert.NotNull(viewModel.TripGroups);
+            Assert.Equal(2, viewModel.TripGroups.Count);
+            Assert.All(viewModel.TripGroups, t => Assert.False(t.IsEditButtonVisible));
+        }
+
+        [Fact]
+        public async Task TripViewModel_LoadsDataAsync_WhenDatabaseIsEmpty()
+        {
+            ClearDatabase();
+
+            _userServiceMock.Setup(us => us.IsDriver()).Returns(true);
+
+            var viewModel = new TripViewModel(new HaulageDbContext(_options), _userServiceMock.Object);
+
+            await viewModel.LoadDataAsync();
+
+            Assert.NotNull(viewModel.TripGroups);
+            Assert.Empty(viewModel.TripGroups);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #22

Introduce ability for admin to check trips (keeping manage expenses, but removing the edit time ability)

- Introducing the page visibility for admins and drivers 
- Admins cannot see the edit time button 
- Drivers still have the ability to edit time 
- Added/updated testing: 
->  TripItemViewModelTests: This class deals with individual trip items and the user’s ability to edit and save changes to a trip.
->  TripViewModelTests: This class represents a higher-level view of all the trips and handles loading the trip data into TripItemViewModel instances.

Testing: 
- Tested the whole flow locally 

**Driver login:** 
![Screenshot 2024-08-23 at 23 06 20](https://github.com/user-attachments/assets/7f020773-92ab-4d36-828e-16fc9a0d2972)
![Screenshot 2024-08-24 at 23 11 55](https://github.com/user-attachments/assets/8d47d851-f45e-46dd-a44c-5eaf3d8433b5)

**Admin login:** 
![Screenshot 2024-08-24 at 23 12 03](https://github.com/user-attachments/assets/b4f21432-4625-4ea6-89e4-39af93d77c7c)

![Screenshot 2024-08-24 at 23 12 37](https://github.com/user-attachments/assets/2e40d5fd-fa83-4ea6-b022-3dee25a04a52)







