### PR TITLE
Adding Ability to Add/Manage Events for Trips

### DIFF
--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -16,8 +16,10 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(NotePage), typeof(NotePage));
         Routing.RegisterRoute("expenses", typeof(ExpensesPage));
         Routing.RegisterRoute("settings", typeof(SettingsPage));
+        Routing.RegisterRoute("events", typeof(AllEventsPage));
         Routing.RegisterRoute(nameof(VehiclePage), typeof(VehiclePage));
         Routing.RegisterRoute(nameof(EditExpensePage), typeof(EditExpensePage));
         Routing.RegisterRoute(nameof(AllBillsPage), typeof(AllBillsPage));
+        Routing.RegisterRoute(nameof(EventPage), typeof(EventPage));
     }
 }

--- a/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
+++ b/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
@@ -16,6 +16,7 @@ namespace HaulageApp.Data
         public virtual DbSet<Vehicle> vehicle { get; set; }
         public virtual DbSet<Expense> expense { get; set; }
         
+        public virtual DbSet<Event> events { get; set; }
         public DbSet<Bill> bill { get; set; }
         
         public DbSet<Item> item { get; set; }

--- a/HaulageApplication/HaulageApp/HaulageApp.csproj
+++ b/HaulageApplication/HaulageApp/HaulageApp.csproj
@@ -106,6 +106,12 @@
       <MauiXaml Update="Views\ManageCustomersPage.xaml">
         <SubType>Designer</SubType>
       </MauiXaml>
+      <MauiXaml Update="Views\AllEventsPage.xaml">
+        <SubType>Designer</SubType>
+      </MauiXaml>
+      <MauiXaml Update="Views\EventPage.xaml">
+        <SubType>Designer</SubType>
+      </MauiXaml>   
     </ItemGroup>
 
     <ItemGroup>
@@ -159,6 +165,14 @@
       </Compile>
       <Compile Update="Views\ManageCustomersPage.xaml.cs">
         <DependentUpon>ManageCustomers.xaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Views\AllEventsPage.xaml.cs">
+        <DependentUpon>AllEventsPage.xaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Views\EventPage.xaml.cs">
+        <DependentUpon>EventPage.xaml</DependentUpon>
         <SubType>Code</SubType>
       </Compile>
     </ItemGroup>

--- a/HaulageApplication/HaulageApp/MauiProgram.cs
+++ b/HaulageApplication/HaulageApp/MauiProgram.cs
@@ -61,6 +61,12 @@ public static class MauiProgram
         builder.Services.AddTransient<EditExpenseViewModel>();
         builder.Services.AddTransient<EditExpensePage>();
         
+        builder.Services.AddTransient<EventViewModel>();
+        builder.Services.AddTransient<EventPage>();
+        
+        builder.Services.AddTransient<AllEventsViewModel>();
+        builder.Services.AddTransient<AllEventsPage>();
+        
         builder.Services.AddTransient<SettingsViewModel>();
         builder.Services.AddTransient<SettingsPage>();
         

--- a/HaulageApplication/HaulageApp/Models/Event.cs
+++ b/HaulageApplication/HaulageApp/Models/Event.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace HaulageApp.Models;
+
+[Table("event")]
+public class Event
+{
+    [Key]
+    [Column("event_id")] 
+    public int Id { get; set; }
+    
+    [ForeignKey(nameof(Trip))]
+    [Column("trip_id")] 
+    public int TripId { get; set; }
+    
+    [Column("event_type")]  
+    public string EventType { get; set; }
+    
+    [Column("timestamp")]  
+    public DateTime? Timestamp { get; set; }
+    
+}

--- a/HaulageApplication/HaulageApp/ViewModels/AllEventsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/AllEventsViewModel.cs
@@ -1,0 +1,75 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using HaulageApp.Data;
+using HaulageApp.Models;
+
+namespace HaulageApp.ViewModels;
+
+public partial class AllEventsViewModel: ObservableObject, IQueryAttributable
+{
+    private readonly HaulageDbContext _context;
+    private Trip? _trip;
+    public ObservableCollection<Event> Events { get; } = [];
+
+    public AllEventsViewModel(HaulageDbContext context)
+    {
+        _context = context;
+    }
+    
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.TryGetValue("trip", out var value))
+        {
+            _trip = value as Trip;
+        }
+        Events.Clear();
+        LoadEventsForTrip(_trip?.Id ?? 0);
+    }
+    
+    private Event? _selectedEvent;
+    public Event? SelectedEvent
+    {
+        get => _selectedEvent;
+        set
+        {
+            if (_selectedEvent != value)
+            {
+                _selectedEvent = value;
+                OnPropertyChanged();
+            }  
+        }
+    }
+    
+    private void LoadEventsForTrip(int tripId)
+    {
+        //fast handle if no trip
+        if (tripId == 0)
+            return;
+
+        Events.Clear();
+        var events = _context.events
+            .AsQueryable()
+            .Where(e => e.TripId == tripId)
+            .ToList();
+
+        foreach (var ev in events)
+        {
+            Events.Add(ev);
+        }
+    }
+    
+    [RelayCommand]
+    private async Task AddEvent()
+    {
+        await Shell.Current.GoToAsync(nameof(Views.EventPage), new Dictionary<string, object>{{ "trip", _trip! }});
+        SelectedEvent = null;  // Clear the selection after navigating
+    }
+    
+    [RelayCommand]
+    private async Task SelectEvent(object item)
+    {
+        await Shell.Current.GoToAsync(nameof(Views.EventPage), new Dictionary<string, object>{{ "trip", _trip! }, { "event", item }});
+        SelectedEvent = null;  // Clear the selection after navigating
+    }
+}

--- a/HaulageApplication/HaulageApp/ViewModels/EventViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/EventViewModel.cs
@@ -1,0 +1,151 @@
+using System.ComponentModel;
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using HaulageApp.Data;
+using HaulageApp.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace HaulageApp.ViewModels;
+
+public partial class EventViewModel : ObservableObject, IQueryAttributable
+{
+    private readonly HaulageDbContext _context;
+    private Event? _event;
+    private Trip? _trip;
+    private string _timestamp;
+
+    public EventViewModel(HaulageDbContext context)
+    {
+        _context = context;
+        _timestamp = String.Empty;
+    }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        try
+        {
+            //Set trip
+            if (query.TryGetValue("trip", out var value))
+            {
+                _trip = value as Trip;
+            }
+            
+            //Set event
+            if (query.TryGetValue("event", out var item))
+            {
+                _event = item as Event;
+                EventType = _event.EventType;
+                TimestampString = _event?.Timestamp?.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture) ?? String.Empty;
+            }
+        }catch (Exception ex)
+        {
+            // Log exception and re-throw
+            Console.WriteLine($"Error: {ex.Message}");
+            throw;
+        }
+    }
+
+    private string? _eventType;
+    public string? EventType
+    {
+        get => _eventType;
+        set 
+        {
+            if (_eventType != value)
+            {
+                _eventType = value;
+                OnPropertyChanged();
+            }  
+        }
+    }
+    
+    public string TimestampString
+    {
+        get => _timestamp;
+        set 
+        {
+            if (_timestamp != value)
+            {
+                _timestamp = value;
+                OnPropertyChanged();
+            }  
+        }
+    }
+
+    [RelayCommand]
+    public async Task Save()
+    {
+        //Check if EventType is null
+        if (string.IsNullOrWhiteSpace(EventType))
+        {
+            await Shell.Current.DisplayAlert("Error", "Invalid Input, Event type must be specified", "Confirm");
+            return;
+        }
+        try
+        {
+            if (_event == null)
+            {
+                // Create a new event
+                _event = new Event
+                {
+                    TripId = _trip?.Id ?? 0,
+                    EventType = EventType,
+                    Timestamp = DateTime.Now
+                };
+                _context.events.Add(_event);
+                await _context.SaveChangesAsync();
+            }
+            else
+            {
+                //Update an event
+                try
+                {
+                    _context.events
+                        .AsQueryable()
+                        .Where(e => e.Id == _event.Id)
+                        .ExecuteUpdate(x => 
+                            x.SetProperty(e => e.EventType, e => EventType)
+                        );
+                    
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                }
+            }
+            await _context.Entry(_event).ReloadAsync();
+            await Shell.Current.GoToAsync($"..?saved={_event.Id}");
+        }
+        catch (Exception ex)
+        {
+            // Handle save exceptions
+            Console.WriteLine($"Error: {ex.Message}");
+            await Shell.Current.DisplayAlert("Error", "Failed to save event", "Confirm");
+        }
+    }
+
+    [RelayCommand]
+    public async Task Delete()
+    {
+        if (_event == null)
+        {
+            await Shell.Current.DisplayAlert("Error", "Cannot delete a new event", "Confirm");
+            return;
+        }
+
+        try
+        {
+            _context.events.Remove(_event);
+            await _context.SaveChangesAsync();
+            await Shell.Current.GoToAsync($"..?deleted={_event.Id}");
+        }
+        catch (Exception ex)
+        {
+            // Handle delete exceptions
+            Console.WriteLine($"Error: {ex.Message}");
+            await Shell.Current.DisplayAlert("Error", "Failed to delete event", "Confirm");
+        }
+    }
+
+}

--- a/HaulageApplication/HaulageApp/ViewModels/TripItemViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/TripItemViewModel.cs
@@ -18,6 +18,7 @@ namespace HaulageApp.ViewModels
         private string _tempEndTimeString;
         
         public ICommand GoToExpensesCommand { get; set; }
+        public ICommand GoToEventsCommand { get; set; }
 
         public TripItemViewModel(Trip trip, HaulageDbContext context)
         {
@@ -41,6 +42,7 @@ namespace HaulageApp.ViewModels
             });
             
             GoToExpensesCommand = new AsyncRelayCommand(GoToExpensesAsync);
+            GoToEventsCommand = new AsyncRelayCommand(GoToEventsAsync);
         }
 
         public int TripId => _trip.Id;
@@ -48,6 +50,12 @@ namespace HaulageApp.ViewModels
         private async Task GoToExpensesAsync()
         {
             await Shell.Current.GoToAsync("expenses",
+                new Dictionary<string, object> { { "trip", _trip } });
+        }
+        
+        private async Task GoToEventsAsync()
+        {
+            await Shell.Current.GoToAsync("events",
                 new Dictionary<string, object> { { "trip", _trip } });
         }
 

--- a/HaulageApplication/HaulageApp/Views/AllEventsPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/AllEventsPage.xaml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             x:Class="HaulageApp.Views.AllEventsPage"
+             Title="Events">
+    
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Add" Command="{Binding AddEventCommand}" IconImageSource="{FontImage Glyph='+', Color=Black, Size=22}" />
+    </ContentPage.ToolbarItems>
+    
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <toolkit:SelectedItemEventArgsConverter x:Key="SelectedItemEventArgsConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    
+    <ListView
+        x:Name="eventList"
+        ItemsSource="{Binding Events}"
+        Margin="20"
+        SelectionMode="Single"
+        SelectedItem="{Binding SelectedEvent, Mode=TwoWay}">
+        <ListView.Behaviors>
+            <toolkit:EventToCommandBehavior
+                EventName="ItemSelected"
+                Command="{Binding SelectEventCommand}"
+                EventArgsConverter="{StaticResource SelectedItemEventArgsConverter}" />
+        </ListView.Behaviors>
+        <ListView.ItemTemplate>
+            <DataTemplate>
+                <TextCell Text="{Binding EventType}"
+                          Detail="{Binding Timestamp}" />
+            </DataTemplate>
+        </ListView.ItemTemplate>
+    </ListView>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/AllEventsPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/AllEventsPage.xaml.cs
@@ -1,0 +1,13 @@
+using HaulageApp.ViewModels;
+
+namespace HaulageApp.Views;
+
+public partial class AllEventsPage : ContentPage
+{
+    public AllEventsPage(AllEventsViewModel viewModel)
+    {
+        BindingContext = viewModel;
+        InitializeComponent();
+    }
+    
+}

--- a/HaulageApplication/HaulageApp/Views/EventPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/EventPage.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HaulageApp.Views.EventPage"
+             Title="Event">
+    <StackLayout Spacing = "10" Padding="10">
+        <Entry x:Name="TypeEditor"
+                Placeholder="Enter the Event Type"
+                Text="{Binding EventType, Mode=TwoWay}"/>
+        <Entry x:Name="Timestamp"
+               Placeholder="This will auto populate (YYYY-MM-DD HH:MM)"
+               Text="{Binding TimestampString}"
+               IsReadOnly="True"/>
+        <Grid ColumnDefinitions="*,*" ColumnSpacing="4">
+            <Button Grid.Column="0"
+                    Text="Save"
+                    Command="{Binding SaveCommand}"/>
+
+            <Button Grid.Column="1"
+                    Text="Delete"
+                    Command="{Binding DeleteCommand}"/>
+        </Grid>
+    </StackLayout>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/EventPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/EventPage.xaml.cs
@@ -1,0 +1,12 @@
+using HaulageApp.ViewModels;
+
+namespace HaulageApp.Views;
+
+public partial class EventPage : ContentPage
+{
+    public EventPage(EventViewModel viewModel)
+    {
+        BindingContext = viewModel;
+        InitializeComponent();
+    }
+}

--- a/HaulageApplication/HaulageApp/Views/TripPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/TripPage.xaml
@@ -49,6 +49,10 @@
                                     Text="Manage expenses"
                                     FontSize="16"
                                     Command="{Binding GoToExpensesCommand}"/>
+                                <Button
+                                    Text="Manage events"
+                                    FontSize="16"
+                                    Command="{Binding GoToEventsCommand}"/>
                             </VerticalStackLayout>
                         </StackLayout>
                     </DataTemplate>

--- a/HaulageApplication/HaulageAppTests/EventViewModelTests.cs
+++ b/HaulageApplication/HaulageAppTests/EventViewModelTests.cs
@@ -1,0 +1,76 @@
+using System.Runtime.CompilerServices;
+using HaulageApp.Data;
+using HaulageApp.Models;
+using HaulageApp.ViewModels;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace HaulageAppTests;
+
+
+public class EventViewModelTests
+{
+    private readonly Mock<HaulageDbContext> _mockContext;
+    private readonly EventViewModel _viewModel;
+    private readonly Mock<DbSet<Event>> _mockEvents;
+    private readonly Trip _trip;
+
+    public EventViewModelTests()
+    {
+        _mockContext = new Mock<HaulageDbContext>();
+        _mockEvents = new Mock<DbSet<Event>>();
+        _viewModel = new EventViewModel(_mockContext.Object);
+        _trip = new Trip { Id = 1, Driver = 2 }; 
+        
+        _mockContext.Setup(e => e.events).Returns(_mockEvents.Object);
+
+    }
+    [Fact]
+    public void ShouldAssignEventWhenQureied()
+    {
+        var events = new Event { Id = 2, TripId = 1, EventType = "Delay", Timestamp = DateTime.Now};
+        var query = new Dictionary<string, object> { { "trip", _trip }, { "event", events } };
+        _viewModel.ApplyQueryAttributes(query);
+        
+        Assert.Equal("Delay", _viewModel.EventType);
+    }
+    
+    [Fact] public Task SaveShouldAddNewEventIfEventIsNull()
+    {
+        _viewModel.ApplyQueryAttributes(new Dictionary<string, object> { { "trip", _trip } }); 
+        _viewModel.EventType = "Delay";
+        
+        _viewModel.Save();
+        
+        _mockEvents.Verify(c => c.Add(It.Is<Event>(e => e.TripId == 1 && e.EventType == "Delay")), Times.Once); 
+        _mockContext.Verify(m => m.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once());
+        return Task.CompletedTask;
+    }
+    
+    [Fact]
+    public Task SaveShouldUpdateEventIfExisting()
+    {
+        var events = new Event { Id = 2, TripId = 1, EventType = "Delay", Timestamp = DateTime.Now};
+        _viewModel.ApplyQueryAttributes(new Dictionary<string, object> { { "event", events } });
+        _viewModel.EventType = "Emergency";
+        
+        _mockContext.Setup(e => e.Entry(events)).Returns(new Mock<FakeEntityEntry<Event>>().Object);
+        _viewModel.Save();
+        
+        _mockEvents.Verify(c => c.AsQueryable(), Times.Once);
+        _mockEvents.Verify(c => c.Add(It.IsAny<Event>()), Times.Never);
+        return Task.CompletedTask;
+    }
+
+    [Fact] public Task DeleteShouldRemoveEvent() 
+    { 
+        var events = new Event { Id = 2, TripId = 1, EventType = "Delay2", Timestamp = DateTime.Now};
+        _viewModel.ApplyQueryAttributes(new Dictionary<string, object> { { "event", events } });
+        
+        _viewModel.Delete();
+        
+        _mockEvents.Verify(c => c.Remove(It.IsAny<Event>()), Times.Once);
+        _mockContext.Verify(m => m.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once());
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Resolves [#14]
Adding the Ability to Manage Events for trips, this allows the editing, addition and deletion of events for a trip. Unit Tests have also been added to test the functionality. Also added validity to not allow null EventType & deletion when a new Event is being created.

Tested flow using iOS 17 iPhone 15 simulator & unit tests pass

<img width="406" alt="image" src="https://github.com/user-attachments/assets/f8342d0a-13d1-4ee6-8835-c27eab38c062">

<img width="406" alt="image" src="https://github.com/user-attachments/assets/efe53a98-4a0d-48d2-a2f4-7e665b1606d2">

<img width="406" alt="image" src="https://github.com/user-attachments/assets/aca5ed5b-21bf-4d83-b4a5-53514e695efb">

<img width="406" alt="image" src="https://github.com/user-attachments/assets/9c52d147-a288-4c95-b260-f87ee429fd3b">

<img width="406" alt="image" src="https://github.com/user-attachments/assets/8634d62a-f196-45e3-ba55-273a52343086">




