### PR TITLE
Adding Ability for customer to see/manage items

### DIFF
--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -59,19 +59,27 @@
                 Route="manageCustomers"/>
         </Tab>
         
-        <Tab Title="Settings" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
-            <ShellContent
-                Title="Settings"
-                ContentTemplate="{DataTemplate views:SettingsPage}"
-                Route="settings" />
-        </Tab>
-        
         <Tab Title="Bills" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
             <ShellContent
                 Title="Bills"
                 ContentTemplate="{DataTemplate views:AllBillsPage}"
                 IsVisible="{Binding BillsIsVisible}"
                 Route="bills" />
+        </Tab>
+        <Tab Title="Items" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
+            <ShellContent
+                Title="Items"
+                ContentTemplate="{DataTemplate views:AllItemsPage}"
+                IsVisible="{Binding BillsIsVisible}" 
+                Route="items" />
+            <!-- Can reuse BillsIsVisible as both Bills and items have same permissions -->
+        </Tab>
+
+        <Tab Title="Settings" Icon="{OnPlatform 'icon_about.png', iOS='icon_about_ios.png', MacCatalyst='icon_about_ios.png'}">
+            <ShellContent
+                Title="Settings"
+                ContentTemplate="{DataTemplate views:SettingsPage}"
+                Route="settings" />
         </Tab>
     </TabBar>
 </Shell>

--- a/HaulageApplication/HaulageApp/AppShell.xaml.cs
+++ b/HaulageApplication/HaulageApp/AppShell.xaml.cs
@@ -17,11 +17,13 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("expenses", typeof(ExpensesPage));
         Routing.RegisterRoute("settings", typeof(SettingsPage));
         Routing.RegisterRoute("events", typeof(AllEventsPage));
+        Routing.RegisterRoute("items", typeof(AllItemsPage));
         Routing.RegisterRoute(nameof(VehiclePage), typeof(VehiclePage));
         Routing.RegisterRoute(nameof(EditExpensePage), typeof(EditExpensePage));
         Routing.RegisterRoute(nameof(AllBillsPage), typeof(AllBillsPage));
         Routing.RegisterRoute(nameof(EditCustomerPage), typeof(EditCustomerPage));
         Routing.RegisterRoute(nameof(EventPage), typeof(EventPage));
         Routing.RegisterRoute(nameof(TripPage), typeof(TripPage));
+        Routing.RegisterRoute(nameof(ItemPage), typeof(ItemPage));
     }
 }

--- a/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
+++ b/HaulageApplication/HaulageApp/Data/HaulageDbContext.cs
@@ -18,6 +18,7 @@ namespace HaulageApp.Data
         public DbSet<Role> role { get; set; }
         public DbSet<Bill> bill { get; set; }  
         public virtual DbSet<Event> events { get; set; }
-        public DbSet<Item> item { get; set; }
+        
+        public virtual DbSet<Item> item { get; set; }
     }
 }

--- a/HaulageApplication/HaulageApp/HaulageApp.csproj
+++ b/HaulageApplication/HaulageApp/HaulageApp.csproj
@@ -114,7 +114,13 @@
       </MauiXaml>
       <MauiXaml Update="Views\EventPage.xaml">
         <SubType>Designer</SubType>
-      </MauiXaml>   
+      </MauiXaml>
+      <MauiXaml Update="Views\AllItemsPage.xaml">
+            <SubType>Designer</SubType>
+      </MauiXaml>
+      <MauiXaml Update="Views\ItemPage.xaml">
+            <SubType>Designer</SubType>
+      </MauiXaml> 
     </ItemGroup>
 
     <ItemGroup>
@@ -181,6 +187,14 @@
       <Compile Update="Views\EventPage.xaml.cs">
         <DependentUpon>EventPage.xaml</DependentUpon>
         <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Views\AllItemsPage.xaml.cs">
+            <DependentUpon>AllItemsPage.xaml</DependentUpon>
+            <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Views\ItemPage.xaml.cs">
+            <DependentUpon>ItemPage.xaml</DependentUpon>
+            <SubType>Code</SubType>
       </Compile>
     </ItemGroup>
 

--- a/HaulageApplication/HaulageApp/MauiProgram.cs
+++ b/HaulageApplication/HaulageApp/MauiProgram.cs
@@ -91,6 +91,12 @@ public static class MauiProgram
 
         builder.Services.AddTransient<AllBillsViewModel>();
         builder.Services.AddTransient<AllBillsPage>();
+        
+        builder.Services.AddTransient<AllItemsViewModel>();
+        builder.Services.AddTransient<ItemViewModel>();
+
+        builder.Services.AddTransient<AllItemsPage>();
+        builder.Services.AddTransient<ItemPage>();
 
  
 #if DEBUG

--- a/HaulageApplication/HaulageApp/ViewModels/AllItemsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/AllItemsViewModel.cs
@@ -1,0 +1,119 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using HaulageApp.Data;
+using HaulageApp.Models;
+using HaulageApp.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HaulageApp.ViewModels;
+
+public partial class AllItemsViewModel: ObservableObject
+{
+
+    private readonly HaulageDbContext _context;
+    public ObservableCollection<Item> AllItems { get;  } = []; 
+
+    private ObservableCollection<int> _billIds;
+    public ObservableCollection<int> BillIds
+    {
+        get => _billIds;
+        private set
+        {
+            if (_billIds != value)
+            {
+                _billIds = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private readonly IUserService _userService;
+    private readonly IBillService _billService;
+    private readonly ILogger<AllItemsViewModel> _logger;
+
+    public AllItemsViewModel(HaulageDbContext context, IUserService userService, IBillService billService, ILogger<AllItemsViewModel> logger)
+    {
+        _context = context;
+        _userService = userService;
+        _billService = billService;
+        _logger = logger;
+    }
+
+    private Item _selectedItem;
+    public Item SelectedItem
+    {
+        get => _selectedItem;
+        set
+        {
+            if (_selectedItem != value)
+            {
+                _selectedItem = value;
+                OnPropertyChanged();
+                // Automatically trigger the SelectItem command when the selection changes
+                SelectItemCommand.Execute(_selectedItem);
+            }
+        }
+    }
+
+    public async Task LoadAllItemsForCustomer()
+    {
+        AllItems.Clear();
+        int userId = _userService.GetCurrentUserId();
+        try
+        {
+            if (userId == 0)
+            {
+                _logger.LogWarning("No User Id found for current user");
+                BillIds = new ObservableCollection<int>();
+                return;
+            }
+
+            var bills = await _billService.GetBillsForCurrentUserAsync(userId);
+            BillIds = new ObservableCollection<int>(
+                bills.Select(b => b.BillId).ToList());
+
+            LoadIdsForItems();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error Loading all items for customer");
+        }
+    }
+
+    private async void LoadIdsForItems()
+    {
+        var items = await _context.item
+            .AsQueryable()
+            .Where(i => BillIds.Contains(i.BillId))
+            .ToListAsync();
+
+        foreach (var i in items)
+        {
+            AllItems.Add(i);
+        }
+    }
+
+    public int GetLatestTripId()
+    {
+        var tripId = _context.trip
+            .AsQueryable()
+            .OrderByDescending(i => i.Id)
+            .First().Id;
+        return tripId == null ? 0 : tripId;
+    }
+
+    [RelayCommand]
+    private async Task AddItem()
+    {
+        await Shell.Current.GoToAsync(nameof(Views.ItemPage), new Dictionary<string, object>{{"billId", _billIds.LastOrDefault()},{"tripId", GetLatestTripId()}});
+    }
+
+    [RelayCommand]
+    private async Task SelectItem()
+    {
+        await Shell.Current.GoToAsync(nameof(Views.ItemPage), 
+            new Dictionary<string, object>{{"billId", _billIds.LastOrDefault()},{"tripId", GetLatestTripId()}, {"item", SelectedItem}});
+    }
+}

--- a/HaulageApplication/HaulageApp/ViewModels/AllItemsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/AllItemsViewModel.cs
@@ -100,7 +100,7 @@ public partial class AllItemsViewModel: ObservableObject
         var tripId = _context.trip
             .AsQueryable()
             .OrderByDescending(i => i.Id)
-            .First().Id;
+            .FirstOrDefault()!.Id;
         return tripId == null ? 0 : tripId;
     }
 

--- a/HaulageApplication/HaulageApp/ViewModels/ItemViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/ItemViewModel.cs
@@ -1,0 +1,181 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using HaulageApp.Data;
+using HaulageApp.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HaulageApp.ViewModels;
+
+public partial class ItemViewModel: ObservableObject, IQueryAttributable
+{
+
+    private readonly HaulageDbContext _context;
+    private readonly ILogger<ItemViewModel> _logger;
+    private Item? _item;
+    private int _billId;
+    private int _tripId;
+
+    public ItemViewModel(HaulageDbContext context, ILogger<ItemViewModel> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.TryGetValue("billId", out var value))
+        {
+            _billId = value as int? ?? 0;
+        }
+        if (query.TryGetValue("tripId", out var value2))
+        {
+            _tripId = (int)value2;
+        }
+        if (query.TryGetValue("item", out var value3))
+        {
+            _item = value3 as Item;
+            if (_item != null)
+            {
+                PickupLocation = _item.PickupLocation;
+                DeliveryLocation = _item.DeliveryLocation;
+                Status = _item.Status;
+            }
+        }
+    }
+
+    private String _pickupLocation;
+    public String PickupLocation
+    {
+        get => _pickupLocation;
+        set
+        {
+            if (_pickupLocation != value)
+            {
+                _pickupLocation = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private String _deliveryLocation;
+    public String DeliveryLocation
+    {
+        get => _deliveryLocation;
+        set
+        {
+            if (_deliveryLocation != value)
+            {
+                _deliveryLocation = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private String _status;
+    public String Status
+    {
+        get => _status;
+        set
+        {
+            if (_status != value)
+            {
+                _status = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    [RelayCommand]
+    public async Task Save()
+    {
+        //Check if PickupLocation, DeliveryLocation or Status is null
+        if (string.IsNullOrWhiteSpace(PickupLocation) || string.IsNullOrWhiteSpace(DeliveryLocation) || string.IsNullOrWhiteSpace(Status))
+        {
+            await Shell.Current.DisplayAlert("Error", "Invalid Input, feilds must be specified " +
+                                                      "\n- Pickup Location must not be null \n- Delivery Location must not be null " +
+                                                      "\n- Status must not be null", "Confirm");
+            return;
+        }
+        // Check if the status is not pending if the Pickup/Delivery locations have been changed
+        if (Status != "pending" && (_item == null || PickupLocation != _item.PickupLocation || DeliveryLocation != _item.DeliveryLocation))
+        {
+            // Show error message and stop saving
+            await Shell.Current.DisplayAlert("Error", "Cannot edit Pickup/Delivery Location when status is not pending.", "Confirm");
+            return;
+        }
+        try
+        {
+            if (_item == null)
+            {
+                //add a new item
+                _item = new Item
+                {
+                    BillId = _billId,
+                    TripId = _tripId,
+                    PickupLocation = PickupLocation,
+                    DeliveryLocation = DeliveryLocation,
+                    Status = Status
+                };
+                _context.item.Add(_item);
+                await _context.SaveChangesAsync();
+            }
+            else //update an existing item
+            {
+                try
+                {
+                    await _context.item
+                        .AsQueryable()
+                        .Where(i => i.ItemId == _item.ItemId)
+                        .ExecuteUpdateAsync(x => x
+                            .SetProperty(i => i.PickupLocation, i => PickupLocation)
+                            .SetProperty(i => i.DeliveryLocation, i => DeliveryLocation)
+                            .SetProperty(i => i.Status, i => Status)
+                        );
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error Saving changes to Item");
+                }
+            }
+
+            await _context.Entry(_item).ReloadAsync();
+            await Shell.Current.GoToAsync($"..?saved={_item.ItemId}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error Saving Item");
+            await Shell.Current.DisplayAlert("Error", "Failed to save item", "Confirm");
+        }
+    }
+
+    [RelayCommand]
+    public async Task Delete()
+    {
+        //Cannot delete a new item
+        if (_item == null)
+        {
+            await Shell.Current.DisplayAlert("Error", "Cannot delete a new item", "Confirm");
+            return;
+        }
+        //Cannot delete item if not status pending
+        if (Status != "pending")
+        {
+            await Shell.Current.DisplayAlert("Error", "Cannot delete item if picked up or delivered", "Confirm");
+            return;
+        }
+
+        try
+        {
+            _context.item.Remove(_item);
+            await _context.SaveChangesAsync();
+            await Shell.Current.GoToAsync($"..?deleted={_item.ItemId}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error Deleting Item");
+            await Shell.Current.DisplayAlert("Error", "Failed to delete item", "Confirm");
+        }
+    }
+
+}

--- a/HaulageApplication/HaulageApp/Views/AllBillsPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/AllBillsPage.xaml
@@ -33,12 +33,16 @@
                                     <CollectionView.ItemTemplate>
                                         <DataTemplate>
                                             <VerticalStackLayout>
-                                                <Label Text="Pickup Location:" FontAttributes="Bold"/>
-                                                <Label Text="{Binding PickupLocation}" TextColor="Gray"/>
-                                                <Label Text="Delivery Location:" FontAttributes="Bold"/>
-                                                <Label Text="{Binding DeliveryLocation}" TextColor="Gray"/>
-                                                <Label Text="Status:" FontAttributes="Bold"/>
-                                                <Label Text="{Binding Status}" TextColor="Gray"/>
+                                                <Frame Padding="10" Margin="5" BorderColor="LightGray" CornerRadius="5">
+                                                    <VerticalStackLayout>
+                                                        <Label Text="Pickup Location:" FontAttributes="Bold"/>
+                                                        <Label Text="{Binding PickupLocation}" TextColor="Gray"/>
+                                                        <Label Text="Delivery Location:" FontAttributes="Bold"/>
+                                                        <Label Text="{Binding DeliveryLocation}" TextColor="Gray"/>
+                                                        <Label Text="Status:" FontAttributes="Bold"/>
+                                                        <Label Text="{Binding Status}" TextColor="Gray"/>
+                                                    </VerticalStackLayout>
+                                                </Frame>
                                             </VerticalStackLayout>
                                         </DataTemplate>
                                     </CollectionView.ItemTemplate>

--- a/HaulageApplication/HaulageApp/Views/AllItemsPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/AllItemsPage.xaml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             x:Class="HaulageApp.Views.AllItemsPage"
+             Title="Items">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Add" Command="{Binding AddItemCommand}" IconImageSource="{FontImage Glyph='+', Color=Black, Size=22}" />
+    </ContentPage.ToolbarItems>
+
+    <ScrollView>
+        <CollectionView x:Name = "itemCollection"
+                        ItemsSource="{Binding AllItems}"
+                        SelectionMode="Single"
+                        SelectedItem="{Binding SelectedItem}"
+                        SelectionChangedCommand="{Binding SelectItemCommand}"
+                        SelectionChangedCommandParameter="{Binding SelectedItem}">
+
+            <CollectionView.ItemsLayout>
+                <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
+            </CollectionView.ItemsLayout>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Frame Padding="10" Margin="5" BorderColor="LightGray" CornerRadius="5" HasShadow="True">
+                        <VerticalStackLayout>
+                            <Label Text="Item Id:" FontSize="Medium" FontAttributes="Bold" TextColor="Black"/>
+                            <Label Text="{Binding ItemId}" FontSize="Medium" TextColor="Black"/>
+                            <Label Text="Pickup Location:" FontSize="Medium" FontAttributes="Bold" TextColor="Black"/>
+                            <Label Text="{Binding PickupLocation}" FontSize="Medium" TextColor="Black"/>
+                            <Label Text="Delivery Location:" FontSize="Medium" FontAttributes="Bold" TextColor="Black"/>
+                            <Label Text="{Binding DeliveryLocation}" FontSize="Medium" TextColor="Black"/>
+                            <Label Text="Status:" FontSize="Medium" FontAttributes="Bold" TextColor="Black"/>
+                            <Label Text="{Binding Status}" FontSize="Medium" TextColor="Black"/>
+                        </VerticalStackLayout>
+                    </Frame>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>    
+        </CollectionView>
+    </ScrollView>
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/AllItemsPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/AllItemsPage.xaml.cs
@@ -1,0 +1,20 @@
+using HaulageApp.ViewModels;
+
+namespace HaulageApp.Views;
+
+public partial class AllItemsPage : ContentPage
+{
+    private AllItemsViewModel _viewModel;
+    public AllItemsPage(AllItemsViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+        _viewModel = viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await _viewModel.LoadAllItemsForCustomer();
+    }
+}

--- a/HaulageApplication/HaulageApp/Views/ItemPage.xaml
+++ b/HaulageApplication/HaulageApp/Views/ItemPage.xaml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HaulageApp.Views.ItemPage"
+             Title="Item">
+    <StackLayout Spacing = "10" Padding="10">
+        <Entry x:Name="PickupLocationEditor"
+               Placeholder="Enter the Pickup Location"
+               Text="{Binding PickupLocation, Mode=TwoWay}"/>
+        <Entry x:Name="DeliveryLocationEditor"
+               Placeholder="Enter the Delivery Location"
+               Text="{Binding DeliveryLocation, Mode=TwoWay}"/>
+        <CollectionView x:Name="StatusSelector"
+                        SelectionMode="Single"
+                        HeightRequest="75"
+                        SelectedItem="{Binding Status}">
+            <CollectionView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>pending</x:String> 
+                    <x:String>picked up</x:String>
+                    <x:String>delivered</x:String>
+                </x:Array>
+            </CollectionView.ItemsSource>
+        </CollectionView>
+        <Grid ColumnDefinitions="*,*" ColumnSpacing="4">
+            <Button Grid.Column="0"
+                    Text="Save"
+                    Command="{Binding SaveCommand}"/>
+
+            <Button Grid.Column="1"
+                    Text="Delete"
+                    Command="{Binding DeleteCommand}"/>
+        </Grid>
+    </StackLayout>
+
+</ContentPage>

--- a/HaulageApplication/HaulageApp/Views/ItemPage.xaml.cs
+++ b/HaulageApplication/HaulageApp/Views/ItemPage.xaml.cs
@@ -1,0 +1,12 @@
+using HaulageApp.ViewModels;
+
+namespace HaulageApp.Views;
+
+public partial class ItemPage : ContentPage
+{
+    public ItemPage(ItemViewModel viewModel)
+    {
+        BindingContext = viewModel;
+        InitializeComponent();
+    }
+}

--- a/HaulageApplication/HaulageAppTests/AllItemsTests.cs
+++ b/HaulageApplication/HaulageAppTests/AllItemsTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.ObjectModel;
+using HaulageApp.Data;
+using HaulageApp.Services;
+using HaulageApp.ViewModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace HaulageAppTests;
+
+public class AllItemsTests
+{
+    private readonly MockDb _mockDb = new();
+    private readonly DbContextOptions<HaulageDbContext> _options;
+    private readonly HaulageDbContext _context;
+    private readonly Mock<IUserService> _userServiceMock;
+    private readonly Mock<IBillService> _billServiceMock;
+    private readonly Mock<ILogger<AllItemsViewModel>> _loggerMock;
+    private readonly AllItemsViewModel _viewModel;
+
+    public AllItemsTests()
+    {
+        _options = _mockDb.CreateContextOptions();
+        _mockDb.CreateContextWithTrips(_options);
+        _context = new HaulageDbContext(_options);
+
+        _userServiceMock = new Mock<IUserService>();
+        _billServiceMock = new Mock<IBillService>();
+        _loggerMock = new Mock<ILogger<AllItemsViewModel>>();
+
+        _viewModel = new AllItemsViewModel(_context, _userServiceMock.Object, _billServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public Task DbShouldReturnAllItemsWhenLoaded()
+    {
+        Assert.Equal(4, _context.item.Count());
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task GetLastestTripShouldReturnLatestTrip()
+    {
+        var tripId = _viewModel.GetLatestTripId();
+        Assert.Equal(2, tripId);
+        return Task.CompletedTask;
+    }
+}

--- a/HaulageApplication/HaulageAppTests/ItemTests.cs
+++ b/HaulageApplication/HaulageAppTests/ItemTests.cs
@@ -1,0 +1,100 @@
+using HaulageApp.Data;
+using HaulageApp.Models;
+using HaulageApp.ViewModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace HaulageAppTests;
+
+public class ItemTests
+{
+    private readonly Mock<DbSet<Item>> _mockItems;
+    private readonly Mock<HaulageDbContext> _mockContext;
+    private readonly Mock<ILogger<ItemViewModel>> _loggerMock;
+    private readonly ItemViewModel _viewModel;
+    private readonly Bill _bill;
+    private readonly Trip _trip;
+    private readonly Item _item;
+
+    public ItemTests()
+    {
+        _mockContext = new Mock<HaulageDbContext>();
+        _mockItems = new Mock<DbSet<Item>>();
+        _loggerMock = new Mock<ILogger<ItemViewModel>>();
+        _viewModel = new ItemViewModel(_mockContext.Object, _loggerMock.Object);
+
+        _bill = new Bill
+        {
+            BillId = 1, CustomerId = 1, Amount = 100.20m, Status = "pending", Items = new List<Item>
+            {
+                new Item { ItemId = 1, PickupLocation = "Loc A", DeliveryLocation = "Loc B", Status = "delivered" },
+                new Item { ItemId = 2, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending" }
+            }
+        };
+
+        _trip = new Trip { Id = 1 };
+
+        _item = new Item
+        {
+            ItemId = 3, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending"
+        };
+
+        _mockContext.Setup(e => e.item).Returns(_mockItems.Object);
+    }
+
+    [Fact]
+    public void ShouldAssignItemWhenQureied()
+    {
+        var query = new Dictionary<string, object> { { "billId", _bill.BillId }, { "item", _item } };
+        _viewModel.ApplyQueryAttributes(query);
+
+        Assert.Equal("Loc C", _viewModel.PickupLocation);
+        Assert.Equal("Loc D", _viewModel.DeliveryLocation);
+        Assert.Equal("pending", _viewModel.Status);
+    }
+
+    [Fact]
+    public Task SaveShouldAddNewItemWhenItemIsNull()
+    {
+        _viewModel.ApplyQueryAttributes(new Dictionary<string, object> { { "billId", 1 },{ "tripId", 1 }});
+
+        _viewModel.PickupLocation = "LocA";
+        _viewModel.DeliveryLocation = "LocB";
+        _viewModel.Status = "pending";
+
+        _viewModel.Save();
+
+        _mockItems.Verify(c => c.Add(It.Is<Item>(i => i.DeliveryLocation == "LocB")), Times.Once); 
+        _mockContext.Verify(m => m.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once());
+        return Task.CompletedTask;
+
+    }
+    [Fact]
+    public Task SaveShouldUpdateEventIfExisting()
+    {
+        _viewModel.ApplyQueryAttributes(new Dictionary<string, object> { { "item", _item } });
+        _viewModel.PickupLocation = "LocC";
+        _viewModel.DeliveryLocation = "LocD";
+        _viewModel.Status = "pending";
+
+        _mockContext.Setup(e => e.Entry(_item)).Returns(new Mock<FakeEntityEntry<Item>>().Object);
+        _viewModel.Save();
+
+        _mockItems.Verify(c => c.AsQueryable(), Times.Once);
+        _mockItems.Verify(c => c.Add(It.IsAny<Item>()), Times.Never);
+        return Task.CompletedTask;
+
+    }
+
+    [Fact] public Task DeleteShouldRemoveEvent() 
+    { 
+        _viewModel.ApplyQueryAttributes(new Dictionary<string, object> { { "item", _item } });
+
+        _viewModel.Delete();
+
+        _mockItems.Verify(c => c.Remove(It.IsAny<Item>()), Times.Once);
+        _mockContext.Verify(m => m.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once());
+        return Task.CompletedTask;
+    }
+}

--- a/HaulageApplication/HaulageAppTests/ItemTests.cs
+++ b/HaulageApplication/HaulageAppTests/ItemTests.cs
@@ -44,7 +44,7 @@ public class ItemTests
     }
 
     [Fact]
-    public void ShouldAssignItemWhenQureied()
+    public void ApplyQueryAttributes_ShouldAssignItemProperties()
     {
         var query = new Dictionary<string, object> { { "billId", _bill.BillId }, { "item", _item } };
         _viewModel.ApplyQueryAttributes(query);

--- a/HaulageApplication/HaulageAppTests/MockDb.cs
+++ b/HaulageApplication/HaulageAppTests/MockDb.cs
@@ -57,6 +57,19 @@ public class MockDb
             new Trip { Id = 1, StartTime = DateTime.Now.AddHours(-2), Status = "ongoing" },
             new Trip { Id = 2, StartTime = DateTime.Now.AddHours(-4), Status = "completed" }
         );
+        
+        context.bill.AddRange(
+            new Bill { BillId = 1, CustomerId = 1, Amount = 100.20m, Status = "pending", Items = new List<Item>
+            {
+                new Item { ItemId = 1, PickupLocation = "Loc A", DeliveryLocation = "Loc B", Status = "delivered" },
+                new Item { ItemId = 2, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending" }
+            }},
+            new Bill { BillId = 2, CustomerId = 4, Amount = 200.00m, Status = "pending", Items = new List<Item>
+            {
+                new Item { ItemId = 3, PickupLocation = "Loc A", DeliveryLocation = "Loc B", Status = "delivered" },
+                new Item { ItemId = 4, PickupLocation = "Loc C", DeliveryLocation = "Loc D", Status = "pending" }
+            } }
+        );
 
         context.SaveChanges();
     }


### PR DESCRIPTION
Resolves [#8]
Adding Ability for customer to view their items, Add new items, edit/delete when not pickedup/delivered. Added Validity checking for null values (pickup location, delivery location & status). Unit tests have also been added

Tested flow using iOS 17 iPhone 15 simulator & unit tests pass

<img width="400" alt="image" src="https://github.com/user-attachments/assets/516749ae-c678-40f7-a68e-2be3dbd35ec2">

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8a093bb0-2d8f-4cdf-8cd2-2a5c93ad1a91">

<img width="400" alt="image" src="https://github.com/user-attachments/assets/494f6811-b1fd-48ba-a5fb-18958f143495">

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b989c1f6-3cf0-423d-b615-e44eab3093ab">


