### PR TITLE
Making Vehicles only viewable by admin & new vehicle can't be deleted

### DIFF
--- a/HaulageApplication/HaulageApp/AppShell.xaml
+++ b/HaulageApplication/HaulageApp/AppShell.xaml
@@ -22,6 +22,7 @@
             <ShellContent
                 Title="Vehicle"
                 ContentTemplate="{DataTemplate views:AllVehiclesPage}"
+                IsVisible="{Binding VehiclesIsVisible}"
                 Route="vehicles" />
         </Tab>
         

--- a/HaulageApplication/HaulageApp/ViewModels/PermissionsViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/PermissionsViewModel.cs
@@ -10,6 +10,7 @@ public partial class PermissionsViewModel : ObservableObject
     [ObservableProperty] private bool _manageCustomersIsVisible;
     [ObservableProperty] private bool _billsIsVisible;
     [ObservableProperty] private bool _tripsIsVisible;
+    [ObservableProperty] private bool _vehiclesIsVisible;
 
     private readonly HaulageDbContext _dbContext;
     private readonly IPreferencesWrapper _preferencesWrapper;
@@ -55,18 +56,21 @@ public partial class PermissionsViewModel : ObservableObject
                 ManageCustomersIsVisible = false;
                 BillsIsVisible = true;
                 TripsIsVisible = false;
+                VehiclesIsVisible = false;
                 break; 
             case 2:
                 // Driver
                 ManageCustomersIsVisible = false;
                 BillsIsVisible = false;
                 TripsIsVisible = true;
+                VehiclesIsVisible = false;
                 break;
             case 3:
                 // Admin
                 ManageCustomersIsVisible = true;
                 BillsIsVisible = false;
                 TripsIsVisible = true;
+                VehiclesIsVisible = true;
                 break;
         }
     }

--- a/HaulageApplication/HaulageApp/ViewModels/VehicleViewModel.cs
+++ b/HaulageApplication/HaulageApp/ViewModels/VehicleViewModel.cs
@@ -101,6 +101,12 @@ public partial class VehicleViewModel : ObservableObject, IQueryAttributable, IN
     [RelayCommand]
     private async Task Delete()
     {
+        if (_vehicle.Id == 0)
+        {
+            await Shell.Current.DisplayAlert("Error", "Cannot delete a new vehicle", "Confirm");
+            return;
+        }
+
         _context.vehicle.Remove(_vehicle);
         _context.SaveChanges();
         await Shell.Current.GoToAsync($"..?deleted={_vehicle.Id}");


### PR DESCRIPTION
Resolves[#16]
Making the vehicles page only viewable by admin & making sure that a new vehicle can't be deleted
Testing:

Tested flow using iPhone 15 simulator running iOS 17